### PR TITLE
Stance in OXA and Discourse Graphs, as a layer, and documented (#3)

### DIFF
--- a/exports/artiushin-2026-spider-atlas.dg.jsonld
+++ b/exports/artiushin-2026-spider-atlas.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/bouyeure-2026-fear-rsa.dg.jsonld
+++ b/exports/bouyeure-2026-fear-rsa.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/ejdrup-2026-dopamine.dg.jsonld
+++ b/exports/ejdrup-2026-dopamine.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/gadeke-2026-guilt-insula.dg.jsonld
+++ b/exports/gadeke-2026-guilt-insula.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -31,37 +32,43 @@
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-agency-aversion-not-guilt",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness cost observed in the Social condition is general agency aversion — the unpleasantness of being the decision-maker as such — and is not contingent on responsibility for a negative outcome befalling the partner.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-guilt-effect-driven-by-own-outcome",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness decrease following negative partner outcomes under participant choice is driven by the participant's own lottery outcome rather than by the partner's, and so reflects self-directed disappointment rather than interpersonal guilt.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-imaging-contrast-invalid",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The imaging pipeline and condition contrasts do not recover established effects, so differences reported between Social and Partner conditions cannot be attributed to the experimental manipulation.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-model-based-glm-invalid",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The model-based fMRI approach does not recover known neural signals, so parametric modulators derived from the computational model — including the partner reward prediction error regressors — cannot be trusted.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-participants-insensitive-to-value",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "Participants did not engage with the lottery task in a value-sensitive way — choices were inattentive or random — so the behavioural measures carry no information about preference or affect.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-social-context-shifts-risk-attitude",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness and choice differences between Social and Partner conditions reflect a social-context-driven shift in risk attitude — participants become more or less risk averse when choosing on another person's behalf — rather than responsibility-contingent interpersonal guilt.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/guilt-effect-independent-of-own-outcome",

--- a/exports/gadeke-2026-guilt-insula.oxa.json
+++ b/exports/gadeke-2026-guilt-insula.oxa.json
@@ -63,6 +63,7 @@
               "value": "The happiness cost observed in the Social condition is general agency aversion — the unpleasantness of being the decision-maker as such — and is not contingent on responsibility for a negative outcome befalling the partner."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "85137f0a-ebf3-4512-8cb6-d6cb9eb6931e",
             "concepts": [
@@ -82,6 +83,7 @@
               "value": "The happiness decrease following negative partner outcomes under participant choice is driven by the participant's own lottery outcome rather than by the partner's, and so reflects self-directed disappointment rather than interpersonal guilt."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "f43ad09b-00ac-4442-820f-b0476e74d25a",
             "concepts": [
@@ -101,6 +103,7 @@
               "value": "The imaging pipeline and condition contrasts do not recover established effects, so differences reported between Social and Partner conditions cannot be attributed to the experimental manipulation."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "d5ba8e97-1aab-40c4-9351-c441d83c5697",
             "concepts": [
@@ -120,6 +123,7 @@
               "value": "The model-based fMRI approach does not recover known neural signals, so parametric modulators derived from the computational model — including the partner reward prediction error regressors — cannot be trusted."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "f5aef1bf-5c3a-43f7-8db7-8f6cac7a0964",
             "concepts": [
@@ -139,6 +143,7 @@
               "value": "Participants did not engage with the lottery task in a value-sensitive way — choices were inattentive or random — so the behavioural measures carry no information about preference or affect."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "1f6b6cc4-c9cf-4fe2-a7fa-a0bbad09aeda",
             "concepts": [
@@ -158,6 +163,7 @@
               "value": "The happiness and choice differences between Social and Partner conditions reflect a social-context-driven shift in risk attitude — participants become more or less risk averse when choosing on another person's behalf — rather than responsibility-contingent interpersonal guilt."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "51c61d6b-8aee-4a0b-b4fa-da89f129bb8f",
             "concepts": [

--- a/exports/headley-2026-inhibitory-rhythms.dg.jsonld
+++ b/exports/headley-2026-inhibitory-rhythms.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/kammer-2026-foveal-feedback.dg.jsonld
+++ b/exports/kammer-2026-foveal-feedback.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/kolb-2026-igabasnfr2.dg.jsonld
+++ b/exports/kolb-2026-igabasnfr2.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -14,6 +15,13 @@
       "https://discoursegraphs.org/ontology#authors": [
         "Kolb et al. (GENIE Project Team + Turner lab)"
       ]
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-signal-from-cross-reactivity",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "The fluorescence response attributed to iGABASnFR2 reflects binding of, or interference by, compounds structurally related to GABA rather than GABA itself, so the reported sensitivity is not a measure of GABA detection.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/crystal-structure-pdb-9d57",
@@ -413,7 +421,7 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/igabasnfr2-gaba-selective-specificity"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/igabasnfr2-fourfold-sensitivity-gain"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-signal-from-cross-reactivity"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
       "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"

--- a/exports/kolb-2026-igabasnfr2.oxa.json
+++ b/exports/kolb-2026-igabasnfr2.oxa.json
@@ -14,6 +14,26 @@
       "children": [
         {
           "type": "Claim",
+          "identifier": "alt-signal-from-cross-reactivity",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "The fluorescence response attributed to iGABASnFR2 reflects binding of, or interference by, compounds structurally related to GABA rather than GABA itself, so the reported sensitivity is not a measure of GABA detection."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "0b8f6f71-6251-48b6-9cca-738ba83a4942",
+            "concepts": [
+              "selectivity",
+              "cross-reactivity",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "crystal-structure-pdb-9d57",
           "role": "methodological",
           "children": [
@@ -290,7 +310,7 @@
           "epistemicStrength": "strong",
           "relations": [
             {
-              "xref": "igabasnfr2-fourfold-sensitivity-gain",
+              "xref": "alt-signal-from-cross-reactivity",
               "relationType": "claimrel:rulesOut"
             },
             {

--- a/exports/rozak-2026-neurovascular-dl.dg.jsonld
+++ b/exports/rozak-2026-neurovascular-dl.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -14,6 +15,13 @@
       "https://discoursegraphs.org/ontology#authors": [
         "Rozak et al."
       ]
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-point-measurement-estimates-vessel-volume",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "Vessel caliber measured at a single point along a capillary is an adequate estimate of microvessel volume change, so point measurements suffice for quantifying neurovascular coupling without volumetric segmentation.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/artery-dilates-venule-unchanged-at-low-power",
@@ -238,7 +246,7 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/baseline-intra-vessel-radius-varies-24pct"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/novas3d-outperforms-ilastik"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-point-measurement-estimates-vessel-volume"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
       "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"
@@ -275,17 +283,6 @@
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#supports",
       "https://discoursegraphs.org/ontology#originalRelationType": "cito:supports"
-    },
-    {
-      "@type": "https://discoursegraphs.org/ontology#Relation",
-      "https://discoursegraphs.org/ontology#source": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/baseline-intra-vessel-radius-varies-24pct"
-      },
-      "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/novas3d-outperforms-ilastik"
-      },
-      "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
-      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:contradicts"
     },
     {
       "@type": "https://discoursegraphs.org/ontology#Relation",

--- a/exports/rozak-2026-neurovascular-dl.formats.json
+++ b/exports/rozak-2026-neurovascular-dl.formats.json
@@ -60,7 +60,7 @@
     }
   },
   "oxa": {
-    "kept": 130,
+    "kept": 129,
     "edges": {
       "claimrel:scopes": 42,
       "cito:confirms": 28,
@@ -72,18 +72,17 @@
       "claimrel:entails": 4,
       "cito:extends": 4,
       "cito:citesAsSourceDocument": 4,
-      "claimrel:rulesOut": 1,
-      "claimrel:contradicts": 1
+      "claimrel:rulesOut": 1
     }
   },
   "dg": {
-    "kept": 130,
+    "kept": 129,
     "edges": {
       "supports": 44,
       "claimrel:scopes": 42,
       "cito:confirms": 28,
       "claimrel:requires": 10,
-      "opposedBy": 6
+      "opposedBy": 5
     }
   },
   "verification": {

--- a/exports/rozak-2026-neurovascular-dl.oxa.json
+++ b/exports/rozak-2026-neurovascular-dl.oxa.json
@@ -14,6 +14,26 @@
       "children": [
         {
           "type": "Claim",
+          "identifier": "alt-point-measurement-estimates-vessel-volume",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Vessel caliber measured at a single point along a capillary is an adequate estimate of microvessel volume change, so point measurements suffice for quantifying neurovascular coupling without volumetric segmentation."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "d58f5ce7-bd4f-461e-9b01-4550aa813eff",
+            "concepts": [
+              "point measurement",
+              "vessel caliber",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "artery-dilates-venule-unchanged-at-low-power",
           "role": "empirical",
           "children": [
@@ -68,7 +88,7 @@
               "relationType": "claimrel:tests"
             },
             {
-              "xref": "novas3d-outperforms-ilastik",
+              "xref": "alt-point-measurement-estimates-vessel-volume",
               "relationType": "claimrel:rulesOut"
             },
             {
@@ -82,10 +102,6 @@
             {
               "xref": "vessel-radius-heterogeneity-stimulation",
               "relationType": "cito:supports"
-            },
-            {
-              "xref": "novas3d-outperforms-ilastik",
-              "relationType": "claimrel:contradicts"
             }
           ],
           "metadata": {

--- a/exports/scheller-2026-self-prioritization.dg.jsonld
+++ b/exports/scheller-2026-self-prioritization.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/exports/wengert-2026-kcnc1.dg.jsonld
+++ b/exports/wengert-2026-kcnc1.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -42,6 +43,13 @@
       "https://discoursegraphs.org/ontology#content": "Kcnc1-A421V/+ mice show significantly reduced body and brain weight relative to WT littermates, but display no detectable abnormalities in gross developmental milestones (fur appearance, eye opening, ear canal opening, incisor eruption, motor benchmarks) assessed at P5–15.",
       "https://discoursegraphs.org/ontology#role": "empirical",
       "https://discoursegraphs.org/ontology#epistemicStrength": "strong"
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-inhibitory-dysfunction-present-juvenile",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "Inhibitory dysfunction in Kcnc1-A421V/+ mice is already established at the juvenile stage (P16-21) rather than emerging with age, so the phenotype is developmentally static rather than progressive.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/excitatory-neurons-unaffected-adult",
@@ -1200,10 +1208,10 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/pv-in-inhibitory-synapse-intact-juvenile"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/inhibitory-dysfunction-progresses-to-adulthood"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-inhibitory-dysfunction-present-juvenile"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
-      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:contradicts"
+      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"
     },
     {
       "@type": "https://discoursegraphs.org/ontology#Relation",

--- a/exports/wengert-2026-kcnc1.formats.json
+++ b/exports/wengert-2026-kcnc1.formats.json
@@ -77,7 +77,7 @@
       "cito:disagreesWith": 4,
       "claimrel:interprets": 4,
       "claimrel:requires": 2,
-      "claimrel:contradicts": 1
+      "claimrel:rulesOut": 1
     }
   },
   "dg": {

--- a/exports/wengert-2026-kcnc1.oxa.json
+++ b/exports/wengert-2026-kcnc1.oxa.json
@@ -163,6 +163,26 @@
         },
         {
           "type": "Claim",
+          "identifier": "alt-inhibitory-dysfunction-present-juvenile",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Inhibitory dysfunction in Kcnc1-A421V/+ mice is already established at the juvenile stage (P16-21) rather than emerging with age, so the phenotype is developmentally static rather than progressive."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "8f0f1866-b184-4166-8ed7-97af70a45e88",
+            "concepts": [
+              "developmental progression",
+              "inhibitory dysfunction",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "excitatory-neurons-unaffected-adult",
           "role": "control",
           "children": [
@@ -1018,8 +1038,8 @@
               "relationType": "claimrel:tests"
             },
             {
-              "xref": "inhibitory-dysfunction-progresses-to-adulthood",
-              "relationType": "claimrel:contradicts"
+              "xref": "alt-inhibitory-dysfunction-present-juvenile",
+              "relationType": "claimrel:rulesOut"
             },
             {
               "xref": "inhibitory-dysfunction-progresses-to-adulthood",

--- a/extract/scripts/export_discourse_graphs.py
+++ b/extract/scripts/export_discourse_graphs.py
@@ -23,6 +23,11 @@ from pathlib import Path
 DG_NS = "https://discoursegraphs.org/ontology#"
 CITO_NS = "http://purl.org/spar/cito/"
 CLAIMREL_NS = "http://elife-claim-trees.org/relations/"
+# Discourse Graphs has no term for the posture a paper takes toward a proposition, any
+# more than MIRA does. Emitting one under `dg:` would assert a term the ontology does not
+# define — the same mistake as reading our exporter's limits back as MIRA's. It goes in
+# our own namespace, matching `haak:stance` in the MIRA export.
+HAAK_NS = "http://elife-claim-trees.org/schema/"
 
 # Role → DG node type mapping
 ROLE_TO_DG_TYPE = {
@@ -120,6 +125,12 @@ def oxa_to_jsonld(oxa_path: Path) -> dict:
             node[f"{DG_NS}epistemicStrength"] = claim["epistemicStrength"]
         if claim.get("metadata", {}).get("doi"):
             node["http://purl.org/ontology/bibo/doi"] = claim["metadata"]["doi"]
+        # A rejected alternative exported as a bare dg:Claim reads as one the paper
+        # makes. The opposing edge gives the argument's direction, not the posture.
+        if claim.get("stance"):
+            node[f"{HAAK_NS}stance"] = claim["stance"]
+        if claim.get("stanceSource"):
+            node[f"{HAAK_NS}stanceSource"] = claim["stanceSource"]
 
         nodes.append(node)
 
@@ -163,6 +174,7 @@ def oxa_to_jsonld(oxa_path: Path) -> dict:
             "dg": DG_NS,
             "cito": CITO_NS,
             "claimrel": CLAIMREL_NS,
+            "haak": HAAK_NS,
             "bibo": "http://purl.org/ontology/bibo/",
         },
         "@graph": [source_node] + nodes + edges,

--- a/extract/scripts/migrate_to_oxa.py
+++ b/extract/scripts/migrate_to_oxa.py
@@ -75,6 +75,25 @@ def parse_claim_file(path: Path) -> dict | None:
     return fm
 
 
+# The four stances a paper can take toward a proposition (claim-format.md §2).
+# Absent means `asserts`.
+STANCES = {"asserts", "entertains", "rejects", "attributes"}
+
+
+def stance_of(fm: dict) -> tuple[str, str | None]:
+    """This paper's stance toward this claim, and the source it attributes it to.
+
+    Stance lives on the assertion because a claim is paper-independent: two papers can
+    hold opposite postures toward one proposition. OXA has no assertion object, and a
+    paper's OXA document describes exactly one paper, so it lands on the claim node here.
+    """
+    a = (fm.get("assertions") or [{}])[0]
+    if not isinstance(a, dict):
+        return "asserts", None
+    st = a.get("stance") or "asserts"
+    return (st if st in STANCES else "asserts"), a.get("source")
+
+
 def to_oxa_claim(fm: dict) -> dict:
     """Convert parsed frontmatter to an OXA Claim node."""
     claim_text = fm.get("claim", "").strip()
@@ -129,6 +148,16 @@ def to_oxa_claim(fm: dict) -> dict:
         node["epistemicStrength"] = epistemic
     if relations:
         node["relations"] = relations
+
+    # Without this, the six alternatives Gädeke argues *against* exported as ordinary
+    # Claim nodes — six propositions the paper denies, read by any consumer as six it
+    # makes. The `rules-out` edge pointing at them gives the direction of the argument
+    # and not the paper's posture, so the node has to carry it.
+    stance, source = stance_of(fm)
+    if stance != "asserts":
+        node["stance"] = stance
+        if source:
+            node["stanceSource"] = source
 
     # Metadata — provenance and auxiliary fields
     meta = {}

--- a/scripts/corpus_facts.py
+++ b/scripts/corpus_facts.py
@@ -150,6 +150,53 @@ def mira_facts(site):
     return out
 
 
+def dangling_eliminations(site):
+    """`rules-out` edges whose target names no claim in the paper.
+
+    Each is an alternative the paper eliminates that has no node to be eliminated — the
+    gap the stance layer exists to close, counted rather than asserted. scripts/
+    check_relations.py reports the same set individually.
+    """
+    n = 0
+    for s in site:
+        d = os.path.join(CLAIMS, s)
+        if not os.path.isdir(d):
+            continue
+        fms = [frontmatter(os.path.join(d, fn)) or {}
+               for fn in sorted(os.listdir(d))
+               if fn.endswith(".md") and fn != "index.md"]
+        known = {fm.get("slug") for fm in fms if fm.get("slug")}
+        for fm in fms:
+            targets = fm.get("rules-out") or []
+            if isinstance(targets, str):
+                targets = [targets]
+            n += sum(1 for x in targets
+                     if isinstance(x, str) and x.strip() not in known and x.strip() != "*")
+    return n
+
+
+def stances(slug):
+    """Claims in this paper the paper does not assert, counted by stance.
+
+    A paper's tree can only record what a result rules out if the rival has a node to be,
+    and the rival is marked by the stance on its assertion, not by its role or its slug —
+    an alternative is functionally a hypothesis, and what makes it a rival is the posture.
+    """
+    out = {}
+    d = os.path.join(CLAIMS, slug)
+    if not os.path.isdir(d):
+        return out
+    for fn in sorted(os.listdir(d)):
+        if not fn.endswith(".md") or fn == "index.md":
+            continue
+        fm = frontmatter(os.path.join(d, fn)) or {}
+        a = (fm.get("assertions") or [{}])[0]
+        st = a.get("stance") if isinstance(a, dict) else None
+        if st and st != "asserts":
+            out[st] = out.get(st, 0) + 1
+    return out
+
+
 def layers(site):
     """Which analytic layer each paper has, detected from the artifacts on disk.
 
@@ -171,6 +218,7 @@ def layers(site):
                                    if r.get("status") == "PASS")
             except Exception:                                         # noqa: BLE001
                 verified = 0
+        st = stances(s)
         out[s] = {
             "tree": has_tree,
             "verification": os.path.isfile(
@@ -181,6 +229,8 @@ def layers(site):
             "coverage": os.path.isfile(os.path.join(ROOT, "mappings", f"{s}.json")),
             "marked": os.path.isfile(os.path.join(ROOT, "marked", f"{s}.marked.md")),
             "agent_trace": os.path.isfile(os.path.join(ROOT, "mappings", f"{s}.json")),
+            "alternatives": bool(st),
+            "alternatives_n": sum(st.values()),
         }
     return out
 
@@ -245,6 +295,7 @@ def main():
         "mira": mira_facts(site),
         "mira_mapping": mira_mapping(),
         "layers": layers(site),
+        "dangling_rules_out": dangling_eliminations(site),
     }
 
     os.makedirs(os.path.dirname(OUT), exist_ok=True)

--- a/site/public/exports/artiushin-2026-spider-atlas.dg.jsonld
+++ b/site/public/exports/artiushin-2026-spider-atlas.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/bouyeure-2026-fear-rsa.dg.jsonld
+++ b/site/public/exports/bouyeure-2026-fear-rsa.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/ejdrup-2026-dopamine.dg.jsonld
+++ b/site/public/exports/ejdrup-2026-dopamine.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/gadeke-2026-guilt-insula.dg.jsonld
+++ b/site/public/exports/gadeke-2026-guilt-insula.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -31,37 +32,43 @@
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-agency-aversion-not-guilt",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness cost observed in the Social condition is general agency aversion — the unpleasantness of being the decision-maker as such — and is not contingent on responsibility for a negative outcome befalling the partner.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-guilt-effect-driven-by-own-outcome",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness decrease following negative partner outcomes under participant choice is driven by the participant's own lottery outcome rather than by the partner's, and so reflects self-directed disappointment rather than interpersonal guilt.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-imaging-contrast-invalid",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The imaging pipeline and condition contrasts do not recover established effects, so differences reported between Social and Partner conditions cannot be attributed to the experimental manipulation.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-model-based-glm-invalid",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The model-based fMRI approach does not recover known neural signals, so parametric modulators derived from the computational model — including the partner reward prediction error regressors — cannot be trusted.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-participants-insensitive-to-value",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "Participants did not engage with the lottery task in a value-sensitive way — choices were inattentive or random — so the behavioural measures carry no information about preference or affect.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/alt-social-context-shifts-risk-attitude",
       "@type": "https://discoursegraphs.org/ontology#Claim",
       "https://discoursegraphs.org/ontology#content": "The happiness and choice differences between Social and Partner conditions reflect a social-context-driven shift in risk attitude — participants become more or less risk averse when choosing on another person's behalf — rather than responsibility-contingent interpersonal guilt.",
-      "https://discoursegraphs.org/ontology#role": "hypothesis"
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/guilt-effect-independent-of-own-outcome",

--- a/site/public/exports/gadeke-2026-guilt-insula.oxa.json
+++ b/site/public/exports/gadeke-2026-guilt-insula.oxa.json
@@ -63,6 +63,7 @@
               "value": "The happiness cost observed in the Social condition is general agency aversion — the unpleasantness of being the decision-maker as such — and is not contingent on responsibility for a negative outcome befalling the partner."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "85137f0a-ebf3-4512-8cb6-d6cb9eb6931e",
             "concepts": [
@@ -82,6 +83,7 @@
               "value": "The happiness decrease following negative partner outcomes under participant choice is driven by the participant's own lottery outcome rather than by the partner's, and so reflects self-directed disappointment rather than interpersonal guilt."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "f43ad09b-00ac-4442-820f-b0476e74d25a",
             "concepts": [
@@ -101,6 +103,7 @@
               "value": "The imaging pipeline and condition contrasts do not recover established effects, so differences reported between Social and Partner conditions cannot be attributed to the experimental manipulation."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "d5ba8e97-1aab-40c4-9351-c441d83c5697",
             "concepts": [
@@ -120,6 +123,7 @@
               "value": "The model-based fMRI approach does not recover known neural signals, so parametric modulators derived from the computational model — including the partner reward prediction error regressors — cannot be trusted."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "f5aef1bf-5c3a-43f7-8db7-8f6cac7a0964",
             "concepts": [
@@ -139,6 +143,7 @@
               "value": "Participants did not engage with the lottery task in a value-sensitive way — choices were inattentive or random — so the behavioural measures carry no information about preference or affect."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "1f6b6cc4-c9cf-4fe2-a7fa-a0bbad09aeda",
             "concepts": [
@@ -158,6 +163,7 @@
               "value": "The happiness and choice differences between Social and Partner conditions reflect a social-context-driven shift in risk attitude — participants become more or less risk averse when choosing on another person's behalf — rather than responsibility-contingent interpersonal guilt."
             }
           ],
+          "stance": "rejects",
           "metadata": {
             "uuid": "51c61d6b-8aee-4a0b-b4fa-da89f129bb8f",
             "concepts": [

--- a/site/public/exports/headley-2026-inhibitory-rhythms.dg.jsonld
+++ b/site/public/exports/headley-2026-inhibitory-rhythms.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/kammer-2026-foveal-feedback.dg.jsonld
+++ b/site/public/exports/kammer-2026-foveal-feedback.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/kolb-2026-igabasnfr2.dg.jsonld
+++ b/site/public/exports/kolb-2026-igabasnfr2.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -14,6 +15,13 @@
       "https://discoursegraphs.org/ontology#authors": [
         "Kolb et al. (GENIE Project Team + Turner lab)"
       ]
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-signal-from-cross-reactivity",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "The fluorescence response attributed to iGABASnFR2 reflects binding of, or interference by, compounds structurally related to GABA rather than GABA itself, so the reported sensitivity is not a measure of GABA detection.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/crystal-structure-pdb-9d57",
@@ -413,7 +421,7 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/igabasnfr2-gaba-selective-specificity"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/igabasnfr2-fourfold-sensitivity-gain"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-signal-from-cross-reactivity"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
       "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"

--- a/site/public/exports/kolb-2026-igabasnfr2.oxa.json
+++ b/site/public/exports/kolb-2026-igabasnfr2.oxa.json
@@ -14,6 +14,26 @@
       "children": [
         {
           "type": "Claim",
+          "identifier": "alt-signal-from-cross-reactivity",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "The fluorescence response attributed to iGABASnFR2 reflects binding of, or interference by, compounds structurally related to GABA rather than GABA itself, so the reported sensitivity is not a measure of GABA detection."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "0b8f6f71-6251-48b6-9cca-738ba83a4942",
+            "concepts": [
+              "selectivity",
+              "cross-reactivity",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "crystal-structure-pdb-9d57",
           "role": "methodological",
           "children": [
@@ -290,7 +310,7 @@
           "epistemicStrength": "strong",
           "relations": [
             {
-              "xref": "igabasnfr2-fourfold-sensitivity-gain",
+              "xref": "alt-signal-from-cross-reactivity",
               "relationType": "claimrel:rulesOut"
             },
             {

--- a/site/public/exports/rozak-2026-neurovascular-dl.dg.jsonld
+++ b/site/public/exports/rozak-2026-neurovascular-dl.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -14,6 +15,13 @@
       "https://discoursegraphs.org/ontology#authors": [
         "Rozak et al."
       ]
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-point-measurement-estimates-vessel-volume",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "Vessel caliber measured at a single point along a capillary is an adequate estimate of microvessel volume change, so point measurements suffice for quantifying neurovascular coupling without volumetric segmentation.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/artery-dilates-venule-unchanged-at-low-power",
@@ -238,7 +246,7 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/baseline-intra-vessel-radius-varies-24pct"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/novas3d-outperforms-ilastik"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-point-measurement-estimates-vessel-volume"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
       "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"
@@ -275,17 +283,6 @@
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#supports",
       "https://discoursegraphs.org/ontology#originalRelationType": "cito:supports"
-    },
-    {
-      "@type": "https://discoursegraphs.org/ontology#Relation",
-      "https://discoursegraphs.org/ontology#source": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/baseline-intra-vessel-radius-varies-24pct"
-      },
-      "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/novas3d-outperforms-ilastik"
-      },
-      "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
-      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:contradicts"
     },
     {
       "@type": "https://discoursegraphs.org/ontology#Relation",

--- a/site/public/exports/rozak-2026-neurovascular-dl.formats.json
+++ b/site/public/exports/rozak-2026-neurovascular-dl.formats.json
@@ -60,7 +60,7 @@
     }
   },
   "oxa": {
-    "kept": 130,
+    "kept": 129,
     "edges": {
       "claimrel:scopes": 42,
       "cito:confirms": 28,
@@ -72,18 +72,17 @@
       "claimrel:entails": 4,
       "cito:extends": 4,
       "cito:citesAsSourceDocument": 4,
-      "claimrel:rulesOut": 1,
-      "claimrel:contradicts": 1
+      "claimrel:rulesOut": 1
     }
   },
   "dg": {
-    "kept": 130,
+    "kept": 129,
     "edges": {
       "supports": 44,
       "claimrel:scopes": 42,
       "cito:confirms": 28,
       "claimrel:requires": 10,
-      "opposedBy": 6
+      "opposedBy": 5
     }
   },
   "verification": {

--- a/site/public/exports/rozak-2026-neurovascular-dl.oxa.json
+++ b/site/public/exports/rozak-2026-neurovascular-dl.oxa.json
@@ -14,6 +14,26 @@
       "children": [
         {
           "type": "Claim",
+          "identifier": "alt-point-measurement-estimates-vessel-volume",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Vessel caliber measured at a single point along a capillary is an adequate estimate of microvessel volume change, so point measurements suffice for quantifying neurovascular coupling without volumetric segmentation."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "d58f5ce7-bd4f-461e-9b01-4550aa813eff",
+            "concepts": [
+              "point measurement",
+              "vessel caliber",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "artery-dilates-venule-unchanged-at-low-power",
           "role": "empirical",
           "children": [
@@ -68,7 +88,7 @@
               "relationType": "claimrel:tests"
             },
             {
-              "xref": "novas3d-outperforms-ilastik",
+              "xref": "alt-point-measurement-estimates-vessel-volume",
               "relationType": "claimrel:rulesOut"
             },
             {
@@ -82,10 +102,6 @@
             {
               "xref": "vessel-radius-heterogeneity-stimulation",
               "relationType": "cito:supports"
-            },
-            {
-              "xref": "novas3d-outperforms-ilastik",
-              "relationType": "claimrel:contradicts"
             }
           ],
           "metadata": {

--- a/site/public/exports/scheller-2026-self-prioritization.dg.jsonld
+++ b/site/public/exports/scheller-2026-self-prioritization.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [

--- a/site/public/exports/wengert-2026-kcnc1.dg.jsonld
+++ b/site/public/exports/wengert-2026-kcnc1.dg.jsonld
@@ -3,6 +3,7 @@
     "dg": "https://discoursegraphs.org/ontology#",
     "cito": "http://purl.org/spar/cito/",
     "claimrel": "http://elife-claim-trees.org/relations/",
+    "haak": "http://elife-claim-trees.org/schema/",
     "bibo": "http://purl.org/ontology/bibo/"
   },
   "@graph": [
@@ -42,6 +43,13 @@
       "https://discoursegraphs.org/ontology#content": "Kcnc1-A421V/+ mice show significantly reduced body and brain weight relative to WT littermates, but display no detectable abnormalities in gross developmental milestones (fur appearance, eye opening, ear canal opening, incisor eruption, motor benchmarks) assessed at P5–15.",
       "https://discoursegraphs.org/ontology#role": "empirical",
       "https://discoursegraphs.org/ontology#epistemicStrength": "strong"
+    },
+    {
+      "@id": "https://elife-claim-trees.org/papers/unknown/alt-inhibitory-dysfunction-present-juvenile",
+      "@type": "https://discoursegraphs.org/ontology#Claim",
+      "https://discoursegraphs.org/ontology#content": "Inhibitory dysfunction in Kcnc1-A421V/+ mice is already established at the juvenile stage (P16-21) rather than emerging with age, so the phenotype is developmentally static rather than progressive.",
+      "https://discoursegraphs.org/ontology#role": "hypothesis",
+      "http://elife-claim-trees.org/schema/stance": "rejects"
     },
     {
       "@id": "https://elife-claim-trees.org/papers/unknown/excitatory-neurons-unaffected-adult",
@@ -1200,10 +1208,10 @@
         "@id": "https://elife-claim-trees.org/papers/unknown/pv-in-inhibitory-synapse-intact-juvenile"
       },
       "https://discoursegraphs.org/ontology#target": {
-        "@id": "https://elife-claim-trees.org/papers/unknown/inhibitory-dysfunction-progresses-to-adulthood"
+        "@id": "https://elife-claim-trees.org/papers/unknown/alt-inhibitory-dysfunction-present-juvenile"
       },
       "https://discoursegraphs.org/ontology#relationType": "https://discoursegraphs.org/ontology#opposedBy",
-      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:contradicts"
+      "https://discoursegraphs.org/ontology#originalRelationType": "claimrel:rulesOut"
     },
     {
       "@type": "https://discoursegraphs.org/ontology#Relation",

--- a/site/public/exports/wengert-2026-kcnc1.formats.json
+++ b/site/public/exports/wengert-2026-kcnc1.formats.json
@@ -77,7 +77,7 @@
       "cito:disagreesWith": 4,
       "claimrel:interprets": 4,
       "claimrel:requires": 2,
-      "claimrel:contradicts": 1
+      "claimrel:rulesOut": 1
     }
   },
   "dg": {

--- a/site/public/exports/wengert-2026-kcnc1.oxa.json
+++ b/site/public/exports/wengert-2026-kcnc1.oxa.json
@@ -163,6 +163,26 @@
         },
         {
           "type": "Claim",
+          "identifier": "alt-inhibitory-dysfunction-present-juvenile",
+          "role": "hypothesis",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Inhibitory dysfunction in Kcnc1-A421V/+ mice is already established at the juvenile stage (P16-21) rather than emerging with age, so the phenotype is developmentally static rather than progressive."
+            }
+          ],
+          "stance": "rejects",
+          "metadata": {
+            "uuid": "8f0f1866-b184-4166-8ed7-97af70a45e88",
+            "concepts": [
+              "developmental progression",
+              "inhibitory dysfunction",
+              "alternative explanation"
+            ]
+          }
+        },
+        {
+          "type": "Claim",
           "identifier": "excitatory-neurons-unaffected-adult",
           "role": "control",
           "children": [
@@ -1018,8 +1038,8 @@
               "relationType": "claimrel:tests"
             },
             {
-              "xref": "inhibitory-dysfunction-progresses-to-adulthood",
-              "relationType": "claimrel:contradicts"
+              "xref": "alt-inhibitory-dysfunction-present-juvenile",
+              "relationType": "claimrel:rulesOut"
             },
             {
               "xref": "inhibitory-dysfunction-progresses-to-adulthood",

--- a/site/src/content/docs/docs/methodology/schema.mdx
+++ b/site/src/content/docs/docs/methodology/schema.mdx
@@ -59,8 +59,44 @@ Edges are top-level keys whose value is a list of target claim slugs. The method
 
 | Field | Type | Meaning |
 |:------|:-----|:--------|
-| `assertions` | list of blocks | Each block links the claim to a specific paper-panel-analysis tuple. Required field — every claim has at least one assertion (the paper that asserts it). |
+| `assertions` | list of blocks | Each block links the claim to a specific paper-panel-analysis tuple, and carries that paper's [`stance`](#stance--what-the-paper-does-with-the-proposition) toward it. Required field — every claim has at least one assertion. |
 | `reproductions` | list of blocks | Each block records a verification attempt: which agent ran it, when, what status (`verified`, `unverified`, `failed:mismatch`, etc.), pointers to the script and reproduced figure. Empty by default; populated by per-paper `verify.py` scripts. |
+
+## Stance — what the paper does with the proposition
+
+A paper does not only assert things. It raises candidates and sets them aside, argues that some are false, and reports what others have claimed. `stance` records which.
+
+| Value | Meaning |
+|:------|:--------|
+| `asserts` | The paper claims this is so. The default; absent means `asserts`. |
+| `entertains` | The paper raises it as a candidate and does not assert it. |
+| `rejects` | The paper argues it is false. |
+| `attributes` | Someone else asserts it; this paper reports that. Requires a citation in `source`. |
+
+**It lives on the assertion, not on the claim.** A claim is paper-independent — the same proposition can be asserted by one paper and rejected by another, and both are facts about the papers rather than about the proposition. Put stance on the claim and those two papers cannot share a node; put it on the assertion and the disagreement becomes queryable.
+
+**There is no value for "rejected".** A claim with `entertains` and an incoming `rules-out` **is** a rejected alternative. One with `entertains` and no such edge is an *open* alternative — a rival the paper raised and did not settle, which is common and was previously inexpressible. Stance says what the paper concluded; the relations say why, and which control did the work.
+
+```yaml
+assertions:
+  - paper-slug: gadeke-2026-guilt-insula
+    doi: 10.7554/eLife.105391
+    stance: rejects
+    method: agent extraction of the alternative addressed by the paper's
+      outcome-independent agency analysis
+```
+
+### Alternatives are claims
+
+This is what makes elimination representable. A claim tree can say what a result supports; it can only say what a result *rules out* if the rival has a node to be. An alternative explanation is authored as an ordinary claim — it takes whatever role it functionally has, usually `hypothesis` — and what marks it as a rival is its stance, not its role or its slug.
+
+Without that node, a `rules-out` edge has nowhere to point, and the failure is not silent absence: the edge goes to the nearest thing that does exist. Five eliminative relations in this corpus were found aimed at claims their own paper asserts, one of which had the graph asserting a contradiction between two compatible findings.
+
+`scripts/check_relations.py` enforces three rules over this: a stance must be one of the four values, `attributes` requires a `source`, and an opposing edge may not target a claim the same paper asserts.
+
+<Aside type="caution" title="Present in the schema, not yet in every paper">
+The machinery is corpus-wide and enforced. The migration is not: alternatives have been authored for Gädeke and three other papers, and eliminative edges elsewhere still point at prose that names no claim. The [Layers page](/elife-claim-trees/layers/) reports which papers have been through this layer.
+</Aside>
 
 ## A real claim file
 

--- a/site/src/content/docs/docs/reference/edges.mdx
+++ b/site/src/content/docs/docs/reference/edges.mdx
@@ -4,6 +4,9 @@ description: The edge inventory between claims. Each edge's reasoning form, mean
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import facts from '../../../../data/corpus-facts.json';
+
+export const n = (k) => facts.relation_counts[k] ?? 0;
 
 Edges are propositions about logical structure between claim entities — not citations. A claim file declares each edge as a top-level YAML key whose value is a list of target claim slugs. Reciprocal edges (`predicts` / `confirms`) are populated symmetrically at build time.
 
@@ -11,22 +14,24 @@ The methodology defines 17 edge types, of which 14 are used in the published cor
 
 ## The edge inventory
 
-| Edge | Reasoning form | Meaning | Count in 12-paper curated corpus |
+| Edge | Reasoning form | Meaning | Count in the published corpus |
 |:-----|:---------------|:--------|---:|
-| `requires` | dependency | A would be invalid if B were false (mechanistic / hierarchical dependency) | 148 |
-| `supports` | abduction (induction) | A provides evidence for B; multiple supports drive the abductive loop | 126 |
-| `entails` | deduction | A (typically a hypothesis) deductively implies B (typically a prediction) | 65 |
-| `derived-from` | deduction | A is the deductive consequence of B; reciprocal of `entails` | 61 |
-| `tests` | deduction → empirical loop | Empirical claim A tests prediction B (closes the hypothesis-prediction-test loop) | 73 |
-| `refutes` | abduction (negative) | A's evidence is incompatible with B (B is the prediction or hypothesis being refuted) | 8 |
-| `rules-out` | elimination | A's evidence eliminates an alternative explanation B | 15 |
-| `dissociates-with` | dissociation (symmetric) | A and B jointly establish a dissociation between two empirical claims | 65 |
-| `validates` | disconfirmation control | A is a control or sign-flip whose specific result strengthens the warrant for B | 54 |
-| `predicts` | predictive validation | A predicts B (typically model-to-experiment) | 3 |
-| `confirms` | predictive validation | Reciprocal of `predicts`; populated at build | 74 |
-| `interprets` | reframing | A reframes empirical B through theoretical lens (an act of mapping, not a derivation) | 42 |
-| `enables-method` | methodological warrant | A is the methodological capability that warrants B's interpretability | 79 |
-| `scopes` | scope qualification | A is a boundary condition on B (or, if `["*"]`, on every empirical claim in the paper) | 197 |
+| `requires` | dependency | A would be invalid if B were false (mechanistic / hierarchical dependency) | {n('requires')} |
+| `supports` | abduction (induction) | A provides evidence for B; multiple supports drive the abductive loop | {n('supports')} |
+| `entails` | deduction | A (typically a hypothesis) deductively implies B (typically a prediction) | {n('entails')} |
+| `derived-from` | deduction | A is the deductive consequence of B; reciprocal of `entails` | {n('derived-from')} |
+| `tests` | deduction → empirical loop | Empirical claim A tests prediction B (closes the hypothesis-prediction-test loop) | {n('tests')} |
+| `refutes` | abduction (negative) | A's evidence is incompatible with B (B is the prediction or hypothesis being refuted) | {n('refutes')} |
+| `rules-out` | elimination | A's evidence eliminates an alternative explanation B | {n('rules-out')} |
+| `dissociates-with` | dissociation (symmetric) | A and B jointly establish a dissociation between two empirical claims | {n('dissociates-with')} |
+| `validates` | disconfirmation control | A is a control or sign-flip whose specific result strengthens the warrant for B | {n('validates')} |
+| `predicts` | predictive validation | A predicts B (typically model-to-experiment) | {n('predicts')} |
+| `confirms` | predictive validation | Reciprocal of `predicts`; populated at build | {n('confirms')} |
+| `interprets` | reframing | A reframes empirical B through theoretical lens (an act of mapping, not a derivation) | {n('interprets')} |
+| `enables-method` | methodological warrant | A is the methodological capability that warrants B's interpretability | {n('enables-method')} |
+| `scopes` | scope qualification | A is a boundary condition on B (or, if `["*"]`, on every empirical claim in the paper) | {n('scopes')} |
+
+Counts are read from `site/src/data/corpus-facts.json`, which `scripts/corpus_facts.py` generates from the claim files themselves — they were hand-typed here until they had all drifted. The denominator is the {facts.papers} published papers; the two method-example papers are counted separately and are not included, which is why `refutes` and `predicts` show zero while the examples below cite them.
 
 ## Edges by reasoning form
 
@@ -50,7 +55,11 @@ The Headley `ca-spikes-couple-20ms-before-ap` `supports` `beta-bidirectional-den
 
 ### Elimination
 
-`rules-out` carries the eliminative move: A's evidence eliminates an explicit alternative B. The corpus carries 15 `rules-out` edges, scattered across papers; they are diagnostically interesting because they are scrubbed by abstracts (the Section 7 synthesis comparator pipeline shows this).
+`rules-out` carries the eliminative move: A's evidence eliminates an explicit alternative B. The corpus carries {n('rules-out')} of them. They are diagnostically interesting because abstracts scrub them — what a paper ruled out is the first thing lost in summary.
+
+**B has to be a claim.** An alternative nobody asserts still needs a node to be eliminated, which is what [`stance`](/elife-claim-trees/docs/methodology/schema/#stance--what-the-paper-does-with-the-proposition) makes possible: the rival is authored as an ordinary claim whose assertion carries `stance: entertains` or `rejects`. Where that node is missing the edge does not vanish, it misfires — {facts.dangling_rules_out} `rules-out` edges in the published corpus still name prose that resolves to no claim, and five were found pointing at claims their own paper asserts.
+
+A `control` claim is the usual source of one. A control exists to eliminate a rival; if the rival is not in the graph, the point of the control is not either — its `validates` edges name the claim it defends and never the alternative it kills.
 
 ### Dissociation
 

--- a/site/src/content/docs/docs/reference/glossary.mdx
+++ b/site/src/content/docs/docs/reference/glossary.mdx
@@ -7,6 +7,8 @@ This glossary defines terms that appear across the documentation. Where a term h
 
 ## Terms
 
+**Alternative.** A rival explanation a paper raises and does not hold. Authored as an ordinary claim — it takes whatever role it functionally has, usually `hypothesis` — and marked as a rival by the `stance` on its assertion rather than by its role or its slug. It exists so that a `rules-out` edge has something to point at; without it the point of every control claim is unrepresented. See [stance](/elife-claim-trees/docs/methodology/schema/#stance--what-the-paper-does-with-the-proposition).
+
 **Claim.** One declarative proposition about the paper's content, anchored to a specific panel (when panel-grounded) or to the paper's argument structure (when hypothesis-, prediction-, or synthesis-level). The atomic unit of the elife-claim-trees schema. See [the claim schema](/elife-claim-trees/docs/methodology/schema/) and `docs/method.md` § 4.
 
 **Claim-type.** The epistemic character of the proposition itself — what kind of knowledge claim it is. One of `empirical`, `interpretive`, `existence`, `synthesis`, `assessment` (the methodology specification) or extended to include `hypothesis`, `prediction`, `scope`, `methodological` per actual corpus usage. Distinct from role.
@@ -40,6 +42,8 @@ This glossary defines terms that appear across the documentation. Where a term h
 **Review modes.** Four options for the `write` subcommand's `--review-mode` flag: `interactive` (analyst edits in `$EDITOR`), `external` (Opus reviewer pass substitutes for analyst), `auto-approve` (no review), `dry-run` (print only). See [review modes — when to use each](/elife-claim-trees/docs/cli/review-modes/).
 
 **Role.** The rhetorical function a claim serves in the paper's argument. One of 9 values: `hypothesis`, `prediction`, `empirical`, `control`, `scope`, `methodological`, `synthesis`, `interpretation`, `literature-context`. Distinct from claim-type. See [the 9 roles](/elife-claim-trees/docs/reference/roles/).
+
+**Stance.** What a paper does with a proposition: `asserts` (the default, and what an absent stance means), `entertains`, `rejects`, or `attributes`. It lives on the assertion rather than on the claim, because a claim is paper-independent and two papers can hold opposite postures toward the same proposition. There is no `rejected` value: `entertains` plus an incoming `rules-out` is a rejected alternative, and `entertains` without one is an open one. See [the claim schema](/elife-claim-trees/docs/methodology/schema/#stance--what-the-paper-does-with-the-proposition).
 
 **Round-trip.** Validation methodology. Run the pipeline on a paper that has a curated reference; score the CLI's output against the reference. Implemented by the `evaluate` subcommand. See [how we measure quality](/elife-claim-trees/docs/validation/methodology/).
 

--- a/site/src/content/docs/docs/reference/roles.mdx
+++ b/site/src/content/docs/docs/reference/roles.mdx
@@ -76,6 +76,8 @@ For the methodology's own description, see `docs/method.md` § 4.2 in the corpus
 
 **What it marks.** An empirical result whose primary work is to **rule out** an alternative explanation. Functional, not contentful — the same proposition could be `empirical` in a different paper context.
 
+**The alternative is a claim too.** A control exists to eliminate a rival, so the rival needs a node for the `rules-out:` edge to reach. It is authored as an ordinary claim taking whatever role it functionally has — usually `hypothesis` — with `stance: entertains` or `rejects` on its assertion marking that this paper does not hold it. See [stance](/elife-claim-trees/docs/methodology/schema/#stance--what-the-paper-does-with-the-proposition). A control whose `validates:` edges name only the claim it defends, and never the alternative it kills, has not recorded the point of the control.
+
 **Signal phrases.**
 - "rules out"
 - "excludes"

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -1,5 +1,6 @@
 {
   "claims": 254,
+  "dangling_rules_out": 9,
   "eligible_claims": 133,
   "eligible_with_record": 133,
   "largest_role": "empirical",
@@ -7,6 +8,8 @@
   "layers": {
     "artiushin-2026-spider-atlas": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -17,6 +20,8 @@
     },
     "bouyeure-2026-fear-rsa": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -27,6 +32,8 @@
     },
     "ejdrup-2026-dopamine": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -37,6 +44,8 @@
     },
     "gadeke-2026-guilt-insula": {
       "agent_trace": true,
+      "alternatives": true,
+      "alternatives_n": 6,
       "coverage": true,
       "formats": true,
       "marked": true,
@@ -47,6 +56,8 @@
     },
     "headley-2026-inhibitory-rhythms": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -57,6 +68,8 @@
     },
     "kammer-2026-foveal-feedback": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -67,6 +80,8 @@
     },
     "kolb-2026-igabasnfr2": {
       "agent_trace": false,
+      "alternatives": true,
+      "alternatives_n": 1,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -77,6 +92,8 @@
     },
     "rozak-2026-neurovascular-dl": {
       "agent_trace": false,
+      "alternatives": true,
+      "alternatives_n": 1,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -87,6 +104,8 @@
     },
     "scheller-2026-self-prioritization": {
       "agent_trace": false,
+      "alternatives": false,
+      "alternatives_n": 0,
       "coverage": false,
       "formats": true,
       "marked": false,
@@ -97,6 +116,8 @@
     },
     "wengert-2026-kcnc1": {
       "agent_trace": false,
+      "alternatives": true,
+      "alternatives_n": 1,
       "coverage": false,
       "formats": true,
       "marked": false,

--- a/site/src/data/mira-validation.json
+++ b/site/src/data/mira-validation.json
@@ -68,8 +68,8 @@
         "mira:addresses",
         "mira:sourceDocument"
       ],
-      "upstream": 9,
-      "violations": 9
+      "upstream": 10,
+      "violations": 10
     },
     "meijer-2025-serotonin-additive-r1": {
       "conforms": false,
@@ -87,8 +87,8 @@
         "mira:addresses",
         "mira:sourceDocument"
       ],
-      "upstream": 16,
-      "violations": 16
+      "upstream": 17,
+      "violations": 17
     },
     "rozak-2026-neurovascular-dl": {
       "conforms": false,
@@ -97,8 +97,8 @@
         "mira:addresses",
         "mira:sourceDocument"
       ],
-      "upstream": 13,
-      "violations": 13
+      "upstream": 14,
+      "violations": 14
     },
     "scheller-2026-self-prioritization": {
       "conforms": false,
@@ -117,12 +117,12 @@
         "mira:addresses",
         "mira:sourceDocument"
       ],
-      "upstream": 15,
-      "violations": 15
+      "upstream": 16,
+      "violations": 16
     }
   },
   "pinned_schema_commit": "483f0b21480c0f4ced9c1519fc0f6df2b8617cfe",
-  "total_violations": 161,
+  "total_violations": 165,
   "upstream_bug": {
     "proof": "docs/schema-mapping/mira-sh-in-bug.jsonld",
     "proof_violations": 2,
@@ -132,5 +132,5 @@
     ],
     "summary": "gen-shacl renders subproperty_of as an sh:in list of slot names, so both properties demand an IRI that is also one of two strings. No document can satisfy them."
   },
-  "upstream_violations": 161
+  "upstream_violations": 165
 }

--- a/site/src/pages/layers.astro
+++ b/site/src/pages/layers.astro
@@ -39,6 +39,7 @@ const shortOf = (slug: string) => {
 
 const slugs = Object.keys(L);
 const count = (k: string) => slugs.filter(s => L[s][k]).length;
+const altTotal = slugs.reduce((n, s) => n + (L[s].alternatives_n ?? 0), 0);
 
 const LAYERS = [
   {
@@ -68,6 +69,13 @@ const LAYERS = [
     question: 'What does the paper assert that no claim represents?',
     detail: `The paper cut into spans, each either accounted for by a claim, adjudicated as asserting no result, or recorded as a gap. This is the layer that measures the claim tree against the paper rather than against itself, and it is the one that produces findings rather than presentation.`,
     covers: `${count('coverage')} of ${slugs.length} papers`,
+  },
+  {
+    v: 'v5', date: '2026-09-10', key: 'alternatives',
+    title: 'Alternatives and stance',
+    question: 'What does this paper rule out, and what does it merely entertain?',
+    detail: `A tree could say what a result supports but not what it eliminates, because a rival nobody asserts had nowhere to be. Alternatives are now claims like any other, and \`stance\` on the assertion records the paper's posture toward each — asserts, entertains, rejects, attributes. A rejected alternative is an \`entertains\` with an incoming \`rules-out\`; an \`entertains\` without one is an open rival, which is common and was previously inexpressible. ${altTotal} propositions across the corpus are now recorded as ones their paper does not assert.`,
+    covers: `${count('alternatives')} of ${slugs.length} papers`,
   },
 ];
 
@@ -133,6 +141,7 @@ const has = (s: string, k: string) => L[s][k];
             <th class="py-2 px-3 font-semibold text-center">v2 verification</th>
             <th class="py-2 px-3 font-semibold text-center">v3 formats</th>
             <th class="py-2 px-3 font-semibold text-center">v4 coverage</th>
+            <th class="py-2 px-3 font-semibold text-center">v5 alternatives</th>
           </tr>
         </thead>
         <tbody>
@@ -155,6 +164,11 @@ const has = (s: string, k: string) => L[s][k];
               </td>
               <td class="py-2 px-3 text-center">{has(s, 'formats') ? <span class="text-emerald-600 dark:text-emerald-400">&#10003;</span> : <span class="text-gray-300 dark:text-gray-700">&mdash;</span>}</td>
               <td class="py-2 px-3 text-center">{has(s, 'coverage') ? <span class="text-emerald-600 dark:text-emerald-400">&#10003;</span> : <span class="text-gray-300 dark:text-gray-700">&mdash;</span>}</td>
+              <td class="py-2 px-3 text-center">
+                {has(s, 'alternatives')
+                  ? <span class="text-emerald-600 dark:text-emerald-400 font-mono text-xs">{L[s].alternatives_n}</span>
+                  : <span class="text-gray-300 dark:text-gray-700">&mdash;</span>}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -200,6 +214,20 @@ const has = (s: string, k: string) => L[s][k];
           schema has no node for, and {facts.mira.verification_records} verification records
           for which no interchange format has a node type at all.
           <a href={`${base}/formats/mira/`} class="text-amber-700 dark:text-amber-400 hover:underline ml-1">MIRA reference</a>
+        </p>
+      </section>
+
+      <section class="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
+        <p class="font-mono text-xs text-amber-700 dark:text-amber-400 m-0 mb-1">v5 &middot; alternatives &middot; 2026-09-10</p>
+        <p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed m-0">
+          A missing node does not only lose information; it misdirects the edges that would
+          have pointed at it. Five eliminative relations were found aiming at claims their own
+          paper asserts, which in Gädeke had the graph asserting a contradiction between two
+          compatible findings. The schema and its checker are corpus-wide; the migration is
+          not. {altTotal} propositions across {count('alternatives')} papers are recorded as
+          ones their paper does not assert, {L['gadeke-2026-guilt-insula']?.alternatives_n ?? 0} of
+          them Gädeke's, and {facts.dangling_rules_out} eliminative edges still point at prose
+          that names no claim.
         </p>
       </section>
 


### PR DESCRIPTION
Fills the three gaps in the stance work: two exporters, the Layers page, and the site's own documentation. Does **not** do the corpus-wide migration — #3 stays open for that.

## 4. Machinery — the OXA and DG exporters were dropping it

`migrate_to_oxa.py` and `export_discourse_graphs.py` emitted Gädeke's six alternatives as ordinary Claim nodes:

```
OXA: 6 alt- claims present
  keys: ['children', 'identifier', 'metadata', 'role', 'type']   ← no stance
DG:  6 alt- nodes present
  keys: ['@id', '@type', '…#content', '…#role']                  ← no stance
```

Six propositions the paper denies, read by any consumer as six it makes — the exact bug the site was fixed for before the stance commit shipped, left live in two of the three downloads the formats pages offer.

Both carry it now. OXA puts `stance` on the claim node (OXA has no assertion object, and a paper's OXA document describes one paper). DG takes it from there under `haak:` rather than `dg:` — the ontology defines no term for posture, and minting one in its namespace would repeat the mistake of reading our exporter's limits back as the schema's.

All ten public papers re-exported: **9 claims across 4 papers** now carry stance in every format that can hold it. Strict MIRA still has none, correctly — it is `sh:closed`, stance lives in the extended file, and the gap report says so per paper.

## 3. A layer

`alternatives` is detected from the claim files like every other layer — a paper has it when some assertion carries a non-default stance — so a paper cannot claim the layer without the annotations. v5 on the timeline, a column in the matrix, a findings section.

Coverage reads **4 of 10**, which is the point: the page exists to make an unfinished layer legible rather than invisible.

## 2. Documentation

The site never mentioned stance except to say MIRA lacks it — a reader was told the standard cannot express something the site had not defined.

- **schema.mdx** — the four values, why stance sits on the assertion rather than the claim, why there is no `rejected` value, why an alternative is an ordinary claim, and an Aside stating that the migration is incomplete.
- **roles.mdx** — a `control` whose edges name only the claim it defends has not recorded the point of the control.
- **glossary.mdx** — Alternative, Stance.
- **edges.mdx** — said the corpus holds 15 `rules-out` edges. It holds 18, and every number in that column had drifted: `scopes` read 197 against 170, `requires` 148 against 99, `entails` 65 against 54. The column now reads from `corpus-facts.json`. `refutes` and `predicts` correctly show 0 — their examples come from the two method-example papers, counted separately, and the page says so.

`corpus_facts.py` also derives `dangling_rules_out`. Worth noting why that matters: writing it by hand would have put **11** on the page, the number `check_relations.py` prints. It is **9** — the hand count included a `scopes` dangler and two papers outside the published corpus.

## 5. Gädeke, checked

| | |
|---|---|
| corpus | 6 claims with `stance: rejects` |
| `check_relations.py` | 0 errors across 12 papers |
| MIRA strict | 0 stance — by design, `sh:closed` |
| MIRA extended | 6 ✅ |
| OXA | 6 ✅ *(new)* |
| Discourse Graphs | 6 ✅ *(new)* |
| gap report | "Stance: claims this paper does not assert" + "Alternatives materialised as claims" |
| paper page | renders A1–A6 under "Alternatives ruled out" |
| MIRA validation | 0 violations of ours |

Site builds 319 pages; both test suites pass.

## What remains on #3

The migration. 45 claims corpus-wide use eliminative language and 6 carry an edge; 9 eliminative edges still point at prose naming no claim. Scheller — a two-hypothesis contest end to end — has 5 eliminative claims and no alternatives at all. That is the p2 work, and none of it is Gädeke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)