### PR TITLE
Launch config so the dev server starts by name

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "site",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "site", "run", "dev"],
+      "port": 4321
+    }
+  ]
+}


### PR DESCRIPTION
One file. `.claude/launch.json` declares the Astro dev server, so `preview_start site` — or any tool that reads this file — starts it without needing to know it lives in `site/`, wants `npm run dev`, and serves on 4321.

```json
{ "name": "site", "runtimeExecutable": "npm",
  "runtimeArgs": ["--prefix", "site", "run", "dev"], "port": 4321 }
```

The `--prefix` form means it works from the repository root, which is where a session usually starts.

Verified by using it: the server this was written for is the one currently serving the site at `http://localhost:4321/elife-claim-trees/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)