### PR TITLE
prediction-outcome: a proposed layer, and the shape a proposal takes

### DIFF
--- a/pipeline/layers.yaml
+++ b/pipeline/layers.yaml
@@ -86,6 +86,31 @@ layers:
     issue: 20
     open: true
 
+  # Declared `proposed`: the question is open, the rule that answers it mechanically exists
+  # and runs, and nothing has been accepted. That is a different state from `relation-vocab`'s
+  # `open: true`, which says a decision is outstanding but carries no machinery to evaluate —
+  # here the rule's behaviour across the whole corpus is the thing to be reviewed.
+  - id: prediction-outcome
+    kind: question
+    scope: corpus
+    status: proposed
+    title: Prediction outcomes
+    question: Did the paper's predictions come out, and does the tree say so?
+    needs: [claim-format, relation-vocab]
+    reads: [scripts/prediction_outcome.py]
+    produces: [review/prediction-outcome.json]
+    views: [table]
+    issue: 28
+    open: true
+    added: "2026-09-11"
+    found: >
+      `tests` is neutral by design, so a tree can record that a prediction was tested and never
+      whether it was met. Of {{prediction_outcome_total}} predictions, {{prediction_outcome_unrecorded}} carry a `tests` edge
+      and no outcome at all. Three wiring conventions are in use and they split by paper, not by
+      case. And the vocabulary is asymmetric: `confirms` exists, nothing means "the result came
+      out against this", so a failed prediction cannot be written down.
+    command: "python3 scripts/prediction_outcome.py --write"
+
   # ── induction ──────────────────────────────────────────────────────────────
   # Fans in: three readers given different slices, reconciled to one draft. The three are
   # `candidate` rather than `step` because keeping them apart is the point — agreement

--- a/review/prediction-outcome.json
+++ b/review/prediction-outcome.json
@@ -1,0 +1,625 @@
+{
+  "layer": "prediction-outcome",
+  "rule_version": 2,
+  "papers": 12,
+  "predictions": 46,
+  "buckets": {
+    "recorded": 8,
+    "unrecorded": 27,
+    "untested": 5,
+    "abstain:conjunction": 1,
+    "abstain:convention": 5
+  },
+  "bucket_notes": {
+    "recorded": "The graph says how the test came out. A `confirms` edge points at the prediction from the result that settled it.",
+    "unrecorded": "A result is wired to the prediction with `tests`, which is neutral, and nothing records the outcome. The paper asserts the result, so a reader would infer the prediction was met -- but that inference is the reader's, not the graph's.",
+    "untested": "Nothing points at this prediction at all. It was derived from a hypothesis and then left unconnected to any result.",
+    "abstain:conjunction": "The prediction states more commitments than it has edges -- \"should show (i)... (ii)... (iii)...\" with fewer results wired than parts. One verdict cannot be right about all of them, so the rule declines rather than picking the majority.",
+    "abstain:convention": "`confirms` without `tests`. Two conventions for wiring outcomes are in use across this corpus, and this prediction follows the one that omits the neutral edge. Which is correct is the question this layer asks, so the rule must not assume an answer."
+  },
+  "conventions": {
+    "bouyeure-2026-fear-rsa": {
+      "tests only": 5
+    },
+    "gadeke-2026-guilt-insula": {
+      "tests only": 4
+    },
+    "headley-2026-inhibitory-rhythms": {
+      "tests only": 6
+    },
+    "kammer-2026-foveal-feedback": {
+      "tests only": 4
+    },
+    "kolb-2026-igabasnfr2": {
+      "tests only": 2
+    },
+    "meijer-2025-serotonin-additive-r1": {
+      "neither": 3,
+      "confirms only": 3
+    },
+    "meijer-2025-serotonin-orthogonal": {
+      "neither": 2,
+      "confirms only": 2
+    },
+    "rozak-2026-neurovascular-dl": {
+      "tests only": 2
+    },
+    "scheller-2026-self-prioritization": {
+      "tests only": 4
+    },
+    "wengert-2026-kcnc1": {
+      "tests+confirms": 9
+    }
+  },
+  "items": [
+    {
+      "paper": "bouyeure-2026-fear-rsa",
+      "prediction": "prediction-context-specificity-increases-during-reversal",
+      "bucket": "unrecorded",
+      "claim": "If PFC context-specific coding is the substrate for context-dependent fear renewal, then context representations should become more distinct (greater within-context vs between-context pattern similarity) in PFC during reversal compared to acquisition, when context becomes newly relevant for predicting threat (the same cue can be safe in one context and dangerous in another).",
+      "tests": [
+        "context-specificity-increases-reversal"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "bouyeure-2026-fear-rsa",
+      "prediction": "prediction-cs-minus-plus-generalizes-reversal",
+      "bucket": "unrecorded",
+      "claim": "If the same generalization mechanism that operates during acquisition is recruited whenever threat is acquired, then during reversal the newly dangerous cue (CS-+, previously safe) should acquire generalized neural representations in fear-network regions, mirroring the pattern seen for CS++ during acquisition.",
+      "tests": [
+        "generalized-pattern-cs-minus-plus-reversal"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "bouyeure-2026-fear-rsa",
+      "prediction": "prediction-cue-generalization-fear-network-acquisition",
+      "bucket": "unrecorded",
+      "claim": "If fear learning recruits a generalization mechanism that encodes threatening cues with shared representations, then during initial acquisition CS+ items should show greater between-item neural pattern similarity than CS- items in canonical fear-network regions (dACC, SFG, caudate, insula), with the generalization signal detectable as a positive CS+ > CS- contrast on the cue-generalization RSA measure.",
+      "tests": [
+        "cue-generalization-increases-acquisition"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "bouyeure-2026-fear-rsa",
+      "prediction": "prediction-item-stability-changing-cues-reversal",
+      "bucket": "unrecorded",
+      "claim": "If reversal learning recruits an item-specific updating strategy in addition to generalization, then changing-valence cues (CS+- and CS-+) should show elevated within-item neural pattern stability — distinguishing each item from its category-mates — in higher-order cortex (precuneus, IFG, prefrontal cortex), regions outside the canonical fear network.",
+      "tests": [
+        "item-stability-precuneus-pfc-reversal"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "bouyeure-2026-fear-rsa",
+      "prediction": "prediction-pfc-context-specificity-tracks-renewal",
+      "bucket": "unrecorded",
+      "claim": "If PFC context-specific coding is the substrate for context-dependent fear renewal, then between-subject variability in PFC context specificity (during reversal) should covary with between-subject variability in subsequent reinstatement of acquisition-phase fear memory traces at test, with subjects who encode contexts more distinctly showing stronger reinstatement.",
+      "tests": [
+        "pfc-context-specificity-predicts-renewal"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "gadeke-2026-guilt-insula",
+      "prediction": "prediction-behavioral-guilt-effect",
+      "bucket": "unrecorded",
+      "claim": "If interpersonal guilt is a real affective phenomenon contingent on responsibility, then in a within-subject lottery paradigm where the same partner outcomes occur under Social and Partner conditions, momentary happiness should drop more after negative partner outcomes in Social trials (participant chose) than in Partner trials (partner chose). This is operationalised as a positive interaction term between partnerWon (low partner outcome) and subjDecided (Social condition) in a mixed-effects regression of happiness on outcomes and responsibility.",
+      "tests": [
+        "guilt-reduces-happiness-after-partner-loss"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "gadeke-2026-guilt-insula",
+      "prediction": "prediction-insula-tracks-guilt",
+      "bucket": "unrecorded",
+      "claim": "If anterior insula encodes interpersonal guilt, then in the trial-level GLM, anterior insula BOLD should be elevated in the Social vs Partner contrast specifically after negative partner outcomes — i.e., the (condition × partner-outcome) interaction should yield a significant positive cluster in the anterior insula, detectable with small-volume FWE correction (SVC) over an a priori anterior-insula ROI derived from prior literature. The signal should not be present for the same contrast after positive partner outcomes (specificity).",
+      "tests": [
+        "insula-tracks-guilt-effect"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "gadeke-2026-guilt-insula",
+      "prediction": "prediction-responsibility-model-wins-comparison",
+      "bucket": "unrecorded",
+      "claim": "If happiness incorporates partner reward prediction errors with a responsibility-weighted rule, then a computational model of happiness that includes a social_pRPE regressor (partner RPE × subject-decided indicator) should fit participant happiness ratings better than nested alternatives that omit the responsibility interaction. Formally: the Responsibility model (and Responsibility Redux model) should achieve lower cross-validated error than baseline (own-reward-only) and additive social-utility models in both Study 1 and Study 2; and the fitted social_pRPE weight should be significantly greater than zero.",
+      "tests": [
+        "responsibility-modulates-guilt-computational"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "gadeke-2026-guilt-insula",
+      "prediction": "prediction-sts-tracks-partner-rpe-under-responsibility",
+      "bucket": "unrecorded",
+      "claim": "If superior temporal sulcus represents the partner's affective experience selectively under responsibility, then in a model-based GLM with trial-by-trial partner RPE regressors split by who-chose, the parametric modulator for partner RPE in Social trials (subject-decided) should yield a significant cluster in left STS, while the parametric modulator for partner RPE in Partner trials (partner-decided) should not. This conditional engagement, rather than a main effect of partner RPE, is the diagnostic prediction.",
+      "tests": [
+        "sts-tracks-partner-reward-prediction-errors"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-beta-optimal-distal",
+      "bucket": "unrecorded",
+      "claim": "If the optimal frequency of rhythmic inhibition at a compartment is set by matching the rhythm period to the local spike timescale, then distal inhibition — where apical Ca²⁺ and NMDA spikes lead the soma by ~20 ms and ~25 ms respectively — should be maximally effective at beta frequencies (~20 Hz), whose period (~50 ms) matches the dendritic-spike lead time.",
+      "tests": [
+        "beta-optimal-distal-dendritic-entrainment"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-distal-dendritic-spike-mechanism",
+      "bucket": "unrecorded",
+      "claim": "If perisomatic and distal dendritic inhibition serve dissociated computational roles, then doubling distal dendritic inhibition should reduce somatic firing primarily by suppressing apical Ca²⁺ and NMDA dendritic spikes, with little change in the somatic AP voltage threshold.",
+      "tests": [
+        "distal-inhib-drops-firing-02hz"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-gamma-optimal-perisomatic",
+      "bucket": "unrecorded",
+      "claim": "If the optimal frequency of rhythmic inhibition at a compartment is set by matching the rhythm period to the local spike timescale, then perisomatic inhibition — where Na+ spikes lead the soma by 2–3 ms — should be maximally effective at gamma frequencies (40–80 Hz), whose periods are commensurate with the 2–3 ms timescale.",
+      "tests": [
+        "gamma-optimal-perisomatic-ap-modulation"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-orthogonal-input-gating",
+      "bucket": "unrecorded",
+      "claim": "If perisomatic and distal dendritic inhibition serve dissociated computational roles, then beta-frequency distal inhibition should gate clustered apical inputs phase-dependently (via dendritic spike control), gamma-frequency perisomatic inhibition should gate clustered proximal/basal inputs phase-dependently (via threshold modulation), and the two gating regimes should be largely independent of each other.",
+      "tests": [
+        "beta-gates-distal-apical-inputs",
+        "gamma-gates-proximal-basal-inputs"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-perisomatic-input-output-shaping",
+      "bucket": "unrecorded",
+      "claim": "If perisomatic inhibition principally regulates somatic action potential generation, then it should reshape the somatic input-output curve through both subtractive (threshold shift) and divisive (gain reduction) effects, rather than producing a pure translation of the operating point.",
+      "tests": [
+        "perisomatic-inhib-subtractive-divisive"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "headley-2026-inhibitory-rhythms",
+      "prediction": "prediction-perisomatic-threshold-mechanism",
+      "bucket": "unrecorded",
+      "claim": "If perisomatic and distal dendritic inhibition serve dissociated computational roles, then doubling perisomatic inhibition should reduce somatic firing primarily by raising the action potential voltage threshold, while leaving apical Ca²⁺ and NMDA dendritic spike rates largely intact.",
+      "tests": [
+        "gamma-perisomatic-no-dendritic-spike-change",
+        "perisomatic-inhib-drops-firing-07hz"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "kammer-2026-foveal-feedback",
+      "prediction": "prediction-cross-decoding-generalizes",
+      "bucket": "unrecorded",
+      "claim": "If foveal feedback shares a representational format with bottom-up sensory drive, a classifier trained on foveal V1 responses in the experimental (feedback) condition should generalize above chance to foveal V1 responses in the control (direct stimulation) condition for the same images.",
+      "tests": [
+        "cross-decoding-experimental-to-control"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "kammer-2026-foveal-feedback",
+      "prediction": "prediction-lo-inverse-pattern",
+      "bucket": "unrecorded",
+      "claim": "If feedback content is selected by the representational level of the receiving cortex, then lateral occipital cortex (LO) — a high-level object-selective region — should show the inverse profile to foveal V1 under feedback: cross-shape decoding should drop while cross-category decoding should remain preserved.",
+      "tests": [
+        "lo-shows-reversed-specificity"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "kammer-2026-foveal-feedback",
+      "prediction": "prediction-u-shape-eccentricity",
+      "bucket": "unrecorded",
+      "claim": "If foveal V1 decoding is genuine top-down feedback rather than passive spillover from large peripheral receptive fields, the eccentricity profile of decoding accuracy in early visual cortex should dip parafoveally and rise again at the fovea (a U-shaped curve), rather than decay monotonically from the peripheral target representation toward the fovea.",
+      "tests": [
+        "u-shaped-eccentricity-rejects-spillover"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "kammer-2026-foveal-feedback",
+      "prediction": "prediction-v1-category-drops-shape-preserved",
+      "bucket": "unrecorded",
+      "claim": "If foveal feedback carries shape but not semantic category information, then in foveal V1, cross-category decoding should drop significantly under feedback (relative to direct stimulation or to a within-category baseline), while cross-shape decoding should remain comparatively preserved.",
+      "tests": [
+        "v1-category-decoding-drops-in-feedback",
+        "v2-v3-generalize-shape-not-category"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "kolb-2026-igabasnfr2",
+      "prediction": "prediction-improved-sensor-enables-new-measurements",
+      "bucket": "unrecorded",
+      "claim": "If iGABASnFR2's improvements (4-fold ΔF/F, 7-fold on-cell affinity, faster rise kinetics, 2P-compatible spectra) cross qualitative capability thresholds, then side-by-side comparison with iGABASnFR1 in three demanding preparations should show: (i) iGABASnFR2 detects single-bouton hippocampal GABA release where iGABASnFR1 yields no signal; (ii) iGABASnFR2 resolves direction-selective starburst GABA release on single trials where iGABASnFR1 cannot resolve direction even after trial-averaging; (iii) iGABASnFR2 detects whisker-evoked volume-transmitted GABA in vivo at cortical layers reachable by 2P imaging.",
+      "tests": [
+        "igabasnfr2-invivo-barrel-cortex",
+        "igabasnfr2-retina-direction-selectivity",
+        "igabasnfr2-single-bouton-hippocampus"
+      ],
+      "confirms": [],
+      "conjuncts": [
+        "i",
+        "ii",
+        "iii"
+      ]
+    },
+    {
+      "paper": "kolb-2026-igabasnfr2",
+      "prediction": "prediction-screen-yields-multiple-improved-variants",
+      "bucket": "unrecorded",
+      "claim": "If the v1 performance ceiling is set by suboptimal residues at identifiable structural sites, then near-saturation mutagenesis at those sites should yield (i) multiple variants exceeding iGABASnFR1 in ΔF/F sensitivity, (ii) at least one variant simultaneously improved on sensitivity and expression / responsive-pixel count, and (iii) potentially variants with qualitatively new behaviour (e.g. inverted response). The screen should not be dominated by single-site marginal improvements.",
+      "tests": [
+        "igabasnfr2-13fold-expression-increase",
+        "igabasnfr2-fourfold-sensitivity-gain",
+        "igabasnfr2n-negative-going-variant",
+        "mutagenesis-3947-variants-screened"
+      ],
+      "confirms": [],
+      "conjuncts": [
+        "i",
+        "ii",
+        "iii"
+      ]
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-5ht-accelerates-prior-update",
+      "bucket": "untested",
+      "claim": "If phasic 5-HT release functions as a surprise / belief-updating signal, then stimulation during the period after a prior-probability block switch should accelerate the rate at which the mouse updates its choice bias toward the new dominant side.",
+      "tests": [],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-5ht-axis-orthogonal-to-choice",
+      "bucket": "abstain:convention",
+      "claim": "If brain-wide 5-HT modulation is structurally separable from the choice computation (under additive modulation), then in a low-dimensional projection of the population response (here, the first three principal components), the vector that separates 5-HT-stimulated from unstimulated trials should be near-orthogonal to the vector that separates left-choice from right-choice trials, with orthogonality measured as 1 - |dot product| of unit-normalized direction vectors.",
+      "tests": [],
+      "confirms": [
+        "5ht-axis-orthogonal-to-choice-axis"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-5ht-shifts-psychometric",
+      "bucket": "untested",
+      "claim": "If phasic 5-HT release alters how the animal weighs sensory evidence against prior expectation, or alters motivation, attention, or visual sensitivity, then 5-HT stimulation should produce detectable changes in psychometric slope, lapse rate, bias, reaction time, or any of the predictor weights of a probabilistic choice model fitting visual evidence, prior, and past choice with separate stimulated/unstimulated coefficients.",
+      "tests": [],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-multiplicative-gain-yields-significant-interaction",
+      "bucket": "untested",
+      "claim": "If serotonergic modulation acted via multiplicative gain modulation — that is, scaling the choice-related component of neural activity rather than shifting it additively — then a per-neuron GLM with choice, stimulation, and choice × stimulation predictors should yield a significantly non-zero interaction coefficient, because under multiplicative scaling the size of the stimulation effect on a neuron depends on the magnitude of its choice-related drive.",
+      "tests": [],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-near-zero-choice-stim-interaction",
+      "bucket": "abstain:convention",
+      "claim": "If serotonergic modulation combines additively with choice-related activity, then a generalized linear model fitted to per-neuron trial-by-trial spike counts with separate predictors for choice (left/right), 5-HT stimulation (on/off), and their interaction (choice × stimulation) should yield a near-zero interaction coefficient when averaged across animals and tested against zero with a one-sample t-test.",
+      "tests": [],
+      "confirms": [
+        "near-zero-choice-by-stim-interaction"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-additive-r1",
+      "prediction": "prediction-orthogonality-grows-toward-choice",
+      "bucket": "abstain:convention",
+      "claim": "If 5-HT modulation occupies a subspace orthogonal to the choice readout dimensions, then the orthogonality measure between the 5-HT effect axis and the choice axis should increase over the pre-choice timecourse — as the choice axis emerges and stabilizes approaching the choice moment, the 5-HT axis should remain in the orthogonal complement rather than aligning with it.",
+      "tests": [],
+      "confirms": [
+        "5ht-axis-orthogonal-to-choice-axis"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-orthogonal",
+      "prediction": "prediction-5ht-accelerates-prior-update",
+      "bucket": "untested",
+      "claim": "If 5-HT signals surprise and supports cognitive flexibility, then optogenetic 5-HT stimulation across blocks of trials should accelerate the rate at which the animal updates its choice bias after a prior-probability block switch — for example, after the prior switches from 80% left to 80% right, 5-HT-stimulated mice should reach the new rightward bias in fewer trials than unstimulated mice.",
+      "tests": [],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-orthogonal",
+      "prediction": "prediction-5ht-axis-orthogonal-to-choice",
+      "bucket": "abstain:convention",
+      "claim": "If brain-wide 5-HT modulation is structurally separable from the choice computation, then in a low-dimensional projection of the population response (here, the first three principal components), the vector that separates 5-HT-stimulated from unstimulated trials should be near-orthogonal to the vector that separates left-choice from right-choice trials, with orthogonality measured as 1 - |dot product| of unit-normalized direction vectors.",
+      "tests": [],
+      "confirms": [
+        "5ht-axis-orthogonal-to-choice-axis"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-orthogonal",
+      "prediction": "prediction-5ht-shifts-psychometric",
+      "bucket": "untested",
+      "claim": "If 5-HT functions as a surprise / belief-updating signal that scales prior dependence or motivation, then optogenetic 5-HT stimulation during the steering-wheel task should produce measurable shifts in at least one of: psychometric slope (visual acuity), bias (prior influence), lapse rate (motivation), percent-correct, reaction time, or in the weight assigned to the visual-evidence / prior / past-choice predictors of a probabilistic choice model.",
+      "tests": [],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "meijer-2025-serotonin-orthogonal",
+      "prediction": "prediction-orthogonality-grows-toward-choice",
+      "bucket": "abstain:convention",
+      "claim": "If the 5-HT modulation specifically avoids the choice readout dimension as that dimension becomes informative, then the orthogonality between the 5-HT axis and the choice axis should not be constant — it should grow over the trial timecourse, becoming maximal in the hundreds of milliseconds leading up to the choice moment, when the choice axis has separated maximally and the readout demand is greatest.",
+      "tests": [],
+      "confirms": [
+        "5ht-axis-orthogonal-to-choice-axis"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "rozak-2026-neurovascular-dl",
+      "prediction": "prediction-pipeline-outperforms-baselines",
+      "bucket": "unrecorded",
+      "claim": "If the DL segmentation + registration + radius-estimation stack genuinely improves on conventional baselines, then (a) the UNet/UNETR ensemble should significantly outperform ilastik on volumetric segmentation metrics (HD95, Dice, precision), (b) cross-time-point registration combined with mask union should recover substantially more vessel segments per FOV than any single time-point segmentation, and (c) the boundary-detection radius estimator should recover known simulated radii with high R² and remain stable to physiologically realistic noise levels.",
+      "tests": [
+        "novas3d-outperforms-ilastik",
+        "radius-estimation-r2-0p68",
+        "registration-doubles-vessel-count",
+        "unetr-outperforms-ilastik-hd95"
+      ],
+      "confirms": [],
+      "conjuncts": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
+    {
+      "paper": "rozak-2026-neurovascular-dl",
+      "prediction": "prediction-pipeline-reveals-network-coordination",
+      "bucket": "unrecorded",
+      "claim": "If the pipeline can resolve network-level neurovascular coupling and if optogenetic activation drives coordinated vascular responses, then in Thy1-ChR2-YFP mice under 458 nm photostimulation we should observe (a) a spatial gradient of dilations vs constrictions relative to labelled neurons, (b) a network-wide rise in assortativity (high-degree vessels coupling with high-degree vessels), (c) a measurable change in capillary network efficiency, and (d) absence of these patterns under 552 nm control illumination and in wild-type mice — none of which would be visible from point-caliber measurements alone.",
+      "tests": [
+        "artery-dilates-venule-unchanged-at-low-power",
+        "baseline-intra-vessel-radius-varies-24pct",
+        "blue-light-dilations-exceed-green-control",
+        "capillary-efficiency-increases-4pct",
+        "constrictions-deeper-than-dilations",
+        "dilations-nearer-neurons-than-constrictions",
+        "network-assortativity-increases-stimulation",
+        "vessel-radius-heterogeneity-stimulation",
+        "wt-controls-no-blue-green-difference"
+      ],
+      "confirms": [],
+      "conjuncts": [
+        "a",
+        "b",
+        "c",
+        "d"
+      ]
+    },
+    {
+      "paper": "scheller-2026-self-prioritization",
+      "prediction": "prediction-additive-effects-other-associated",
+      "bucket": "unrecorded",
+      "claim": "If social and perceptual salience operate via independent mechanisms, then for stimuli that are simultaneously socially salient (other-associated) and perceptually salient (high local contrast) the observed processing rate change should equal — within statistical uncertainty — the sum of the social-only and perceptual-only effects estimated from the marginal conditions, with the interaction term not reliably distinguishable from zero. The prediction is most cleanly testable in Experiment 2's factorial design, where social association (self / other / neutral) is crossed with perceptual salience (high-contrast / low-contrast). For self-associated stimuli the prediction is held in reserve — any deviation from additivity in the self condition would localise the exception rather than refute the general independence claim.",
+      "tests": [
+        "self-social-additive-perceptual"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "scheller-2026-self-prioritization",
+      "prediction": "prediction-capacity-model-outperforms-weights-only",
+      "bucket": "unrecorded",
+      "claim": "If self-association mobilises additional encoding capacity rather than merely redistributing fixed attentional weights, a hierarchical TVA model in which the C parameter is allowed to take a separate value in each experimental condition should fit the participant-level data substantially better than a single-C model in which capacity is held fixed across conditions and only the relative weights vary. Operationally, on a leave-one-out cross-validation comparison the indiv-C model should win on Δloo and on the model-stacking weight, with the magnitude large enough to be taken seriously after accounting for the standard error of the difference.",
+      "tests": [
+        "tva-capacity-model-wins"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "scheller-2026-self-prioritization",
+      "prediction": "prediction-self-advantage-attenuated-social-decision",
+      "bucket": "unrecorded",
+      "claim": "If the automatic perceptual self-prioritisation and the deliberate social-identity decoding stages compete for the same finite attentional resource, then requiring an explicit social decision (whose shape flickered first?) should attenuate, eliminate, or even reverse the self-advantage observed in the perceptual decision condition. The reversal direction is non-trivial — naive accounts of self-prioritisation predict that explicit attention to identity should amplify, not diminish, the self-advantage. The prediction here is the opposite: when participants must allocate resources to the social-decoding stage, the upstream perceptual self-prioritisation cannot proceed unimpeded, and the net measured advantage shrinks toward zero or flips toward an other-associated advantage.",
+      "tests": [
+        "other-association-advantage-social-condition",
+        "self-prioritization-absent-social-decision"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "scheller-2026-self-prioritization",
+      "prediction": "prediction-self-advantage-perceptual-decision",
+      "bucket": "unrecorded",
+      "claim": "If self-association alters early attentional selection automatically, then in a temporal order judgement task that requires only a perceptual report (which shape flickered first?) the self-associated stimulus should show a faster TVA processing rate than the other-associated stimulus, even though the social identity of either shape is irrelevant to the response. The advantage should manifest as a positive shift in (v_self − v_other) relative to the neutral baseline condition and should be present despite participants having no task incentive to attend to social identity.",
+      "tests": [
+        "self-prioritization-perceptual-decision-automatic"
+      ],
+      "confirms": [],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-cognitive-deficits",
+      "bucket": "recorded",
+      "claim": "If PV-IN dysfunction in Kcnc1-A421V/+ mice impairs the inhibitory circuits underlying cortical learning and plasticity, then mutant mice should show measurable cognitive deficits in tasks that depend on PV-IN-supported processes — specifically spatial learning (Barnes maze, with deficits most evident during the acquisition phase) and spatial working memory (Y-maze spontaneous alternation). The deficit should be specific (not attributable to locomotor or exploratory confounds) and should recapitulate the moderate-to-severe developmental delay seen in human KCNC1 DEE patients. Long-term memory retention (Barnes maze probe trial) may or may not be intact, depending on whether the deficit is in learning rate or memory storage.",
+      "tests": [
+        "a421v-spatial-learning-working-memory-impaired"
+      ],
+      "confirms": [
+        "a421v-spatial-learning-working-memory-impaired"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-excitatory-neurons-spared",
+      "bucket": "recorded",
+      "claim": "If the A421V variant exerts its cellular effect specifically through Kv3.1 — which is not expressed at functionally relevant levels in cortical excitatory neurons — then excitatory neurons in Kcnc1-A421V/+ mice should be functionally spared: voltage-gated K+ current density, intrinsic excitability (firing-frequency vs current-injection relationship), AP waveform parameters, and synaptic transmission should not differ significantly from WT. The null result must hold at both juvenile and adult stages to exclude both cell-autonomous and secondary network effects on excitatory cells. This is the negative-control half of the cell-type specificity test.",
+      "tests": [
+        "excitatory-neurons-unaffected-adult",
+        "excitatory-neurons-unaffected-juvenile"
+      ],
+      "confirms": [
+        "excitatory-neurons-unaffected-adult",
+        "excitatory-neurons-unaffected-juvenile"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-impairment-grades-with-kv31-dependence",
+      "bucket": "recorded",
+      "claim": "If the impairment is specifically Kv3.1-mediated, then within the population of fast-spiking PV-INs the magnitude of phenotype should grade with the relative expression of Kv3.1 versus the partially redundant Kv3.2 subunit. Specifically, superficial neocortical PV-INs (layer II–IV; predominantly Kv3.1) should show the largest deficit; deep neocortical PV-INs (layer V; greater Kv3.2 expression) should show milder deficits confined to the highest current injections; and reticular thalamic nucleus (RTN) PV-INs (predominantly Kv3.1 and Kv3.3, no Kv3.2 compensation) should also show impairment but with a phenotype shaped by their distinctive rebound firing physiology. This graded prediction is a stronger discriminator of mechanism than a single-population test, because alternative mechanisms (generic PV vulnerability, generic neocortical defect) cannot easily produce a Kv3.1:Kv3.2- ratio-aligned gradient.",
+      "tests": [
+        "layer-v-pv-ins-subtle-impairment",
+        "rtn-neurons-impaired-excitability"
+      ],
+      "confirms": [
+        "layer-v-pv-ins-subtle-impairment",
+        "rtn-neurons-impaired-excitability"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-kv31-surface-expression-reduced",
+      "bucket": "recorded",
+      "claim": "If the A421V variant impairs Kv3.1 surface trafficking — rather than channel gating per se — then heterozygous Kcnc1-A421V/+ PV-INs should show a measurable reduction in the membrane-localized fraction of Kv3.1 protein, accompanied by relative enrichment of cytosolic Kv3.1 (likely in the endoplasmic reticulum). Quantitatively, the membrane:cytosol fluorescence intensity ratio measured by immunohistochemistry should be significantly lower in mutant PV-INs. As a corollary, the voltage-dependence of activation and the activation kinetics of the residual K+ current should not differ between WT and mutant, because the channels that do reach the surface are predominantly WT homotetramers (or contain functional channels with normal gating).",
+      "tests": [
+        "a421v-kv31-membrane-trafficking-impaired"
+      ],
+      "confirms": [
+        "a421v-kv31-membrane-trafficking-impaired"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-network-hyperexcitability-in-vivo",
+      "bucket": "recorded",
+      "claim": "If PV-IN dysfunction reduces effective perisomatic inhibition in vivo, then awake Kcnc1-A421V/+ mice should show measurable signatures of cortical hyperexcitability by two-photon calcium imaging: (i) paroxysmal hypersynchronous neuropil discharges not present in WT, reflecting brief network-wide bursts of activity, and (ii) elevated calcium transient frequency in PV-negative (excitatory) cells during low-arousal states, reflecting tonic disinhibition. These signatures should be state-dependent — present during quiet rest, when tonic inhibition normally dominates — and may be masked or compensated during active arousal states (e.g. running) when other modulatory inputs dominate cortical state.",
+      "tests": [
+        "in-vivo-hypersynchronous-discharges-mutant-only",
+        "in-vivo-pv-minus-transient-frequency-increased"
+      ],
+      "confirms": [
+        "in-vivo-hypersynchronous-discharges-mutant-only",
+        "in-vivo-pv-minus-transient-frequency-increased"
+      ],
+      "conjuncts": [
+        "i",
+        "ii"
+      ]
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-progressive-synaptic-failure",
+      "bucket": "recorded",
+      "claim": "If PV-IN spike output is impaired from juvenile stages but the synaptic terminal release machinery requires further developmental maturation (or accumulates pathological adaptations) to manifest a measurable phenotype, then PV-IN→excitatory unitary inhibitory synaptic transmission should be normal at juvenile stages (P16–21) and altered at young adult stages (P32–42). The adult alteration should carry a presynaptic signature consistent with altered release dynamics — for example, increased uIPSC amplitude with reduced paired-pulse ratio (enhanced initial release probability with faster depression). The temporal dissociation is a refinement of the disease-mechanism hypothesis: it specifies that the inhibitory failure is developmentally emergent, not congenital, at the synaptic level.",
+      "tests": [
+        "pv-in-inhibitory-synapse-altered-adult",
+        "pv-in-inhibitory-synapse-intact-juvenile"
+      ],
+      "confirms": [
+        "inhibitory-dysfunction-progresses-to-adulthood",
+        "pv-in-inhibitory-synapse-altered-adult"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-pv-in-firing-impaired",
+      "bucket": "recorded",
+      "claim": "If Kv3.1 LOF selectively impairs the cell type that depends on it, then PV-INs in Kcnc1-A421V/+ mice should show reduced maximal sustained firing frequency, slower AP downstroke (reflecting impaired repolarization), and prolonged AP half-duration (APD50) under whole-cell current-clamp recording. Passive membrane properties (resting Vm, input resistance) and AP threshold should be preserved, because Kv3 channels operate at suprathreshold voltages and are not the dominant determinants of the resting state. The phenotype should be present at juvenile stages (P16–21), before any secondary network adaptations have occurred, as a cell-autonomous consequence of reduced Kv3.1 current.",
+      "tests": [
+        "pv-in-ap-waveform-altered-downstroke-apd50",
+        "pv-ins-impaired-maximal-firing"
+      ],
+      "confirms": [
+        "pv-in-ap-waveform-altered-downstroke-apd50",
+        "pv-ins-impaired-maximal-firing"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-pv-in-k-current-reduced",
+      "bucket": "recorded",
+      "claim": "If KCNC1-A421V is a Kv3.1 loss-of-function variant, heterozygous PV-INs in the Kcnc1-A421V/+ knock-in mouse should show a quantitatively measurable reduction in voltage-gated potassium current density relative to WT littermates, measured by whole-cell or nucleated macropatch recording in the voltage range where Kv3 channels carry the dominant outward current (positive to ~0 mV). The reduction should be larger than the 50% expected from simple haploinsufficiency, because Kv3 channels function as obligate tetramers and a dominant-negative mutant subunit incorporated into heteromeric tetramers can disable more than half of channel surface delivery.",
+      "tests": [
+        "pv-ins-reduced-k-current-density"
+      ],
+      "confirms": [
+        "pv-ins-reduced-k-current-density"
+      ],
+      "conjuncts": []
+    },
+    {
+      "paper": "wengert-2026-kcnc1",
+      "prediction": "prediction-seizures-and-sudep",
+      "bucket": "abstain:conjunction",
+      "claim": "If the inhibitory failure produced by Kv3.1 LOF is sufficient to drive the encephalopathy phenotype, then Kcnc1-A421V/+ mice should exhibit (i) spontaneous convulsive seizures captured on continuous video-EEG, (ii) seizure-induced sudden death (SUDEP) at high penetrance, and (iii) premature mortality with all mutants dying before reaching natural lifespan endpoints. The seizure types should match the spectrum reported in human KCNC1 DEE (myoclonic events, generalized tonic-clonic), and the SUDEP events should be preceded by tonic-clonic seizures with hindlimb extension — the canonical mouse SUDEP signature.",
+      "tests": [
+        "spontaneous-seizures-and-sudep-kcnc1"
+      ],
+      "confirms": [
+        "a421v-mice-die-before-122d",
+        "spontaneous-seizures-and-sudep-kcnc1"
+      ],
+      "conjuncts": [
+        "i",
+        "ii",
+        "iii"
+      ]
+    }
+  ]
+}

--- a/scripts/corpus_facts.py
+++ b/scripts/corpus_facts.py
@@ -308,6 +308,40 @@ def pipeline_state():
         return None
 
 
+def prediction_outcomes():
+    """The prediction-outcome layer's own numbers, read from the manifest it produces.
+
+    Read rather than recomputed: the manifest is the layer's output, and a second
+    implementation here would be a second answer to one question -- which is the failure the
+    pipeline exists to close. If the manifest is absent the layer has not been run, and the
+    facts say so rather than inventing zeroes that would read as findings.
+    """
+    path = os.path.join(ROOT, "review", "prediction-outcome.json")
+    if not os.path.isfile(path):
+        return {}
+    with open(path, encoding="utf-8") as fh:
+        d = json.load(fh)
+    b = d.get("buckets", {})
+    conv = d.get("conventions", {})
+    kinds = set()
+    for counts in conv.values():
+        kinds.update(counts)
+    return {
+        "rule_version": d.get("rule_version"),
+        # Flat scalars as well as the nested buckets: the site's {{token}} resolver flattens
+        # one level only, so a count buried inside `buckets` cannot be cited in a declaration's
+        # `found` text. These are the ones the prose needs.
+        "total": d.get("predictions", 0),
+        "recorded": b.get("recorded", 0),
+        "unrecorded": b.get("unrecorded", 0),
+        "untested": b.get("untested", 0),
+        "buckets": b,
+        "conventions": conv,
+        "convention_kinds": len(kinds),
+        "abstained": sum(v for k, v in b.items() if k.startswith("abstain")),
+    }
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--print", dest="show", action="store_true")
@@ -350,6 +384,7 @@ def main():
         # `layers` above detects presence from artifacts on disk and stays as the simpler
         # answer; this says *current / stale / absent / blocked*, which presence cannot.
         "pipeline": pipeline_state(),
+        "prediction_outcome": prediction_outcomes(),
     }
 
     os.makedirs(os.path.dirname(OUT), exist_ok=True)

--- a/scripts/prediction_outcome.py
+++ b/scripts/prediction_outcome.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Did the paper's predictions come out, and does the tree say so?
+
+A prediction is a commitment made in advance. A claim tree that records which result *tested*
+a prediction, and never whether the test came out for or against it, has recorded the setup
+and dropped the result.
+
+`tests` is neutral on purpose -- `X tests P` says X bears on P, not which way it went. The
+vocabulary has a positive counterpart, `confirms`, used 74 times corpus-wide. What it has no
+counterpart for is failure: nothing in the vocabulary says "the result came out against this
+prediction". `contradicts` and `rules-out` do not fill the gap, because both assert the target
+is *false*, and a refuted prediction is not a false statement -- it was a correct derivation
+from its hypothesis, and what the failure damages is the hypothesis, one edge upstream.
+
+So the corpus can record that a prediction succeeded and cannot record that one failed. Every
+tree we publish will look like a paper whose predictions all worked out.
+
+WHAT THIS DOES, AND WHAT IT DELIBERATELY DOES NOT
+
+It classifies each prediction by the *shape of the graph around it* -- which edges point at it,
+and whether the prediction's own text enumerates more commitments than it has edges. That is
+mechanical and checkable.
+
+It does NOT judge whether a testing result actually matches the prediction it is wired to.
+That is a semantic reading, it needs an agent or a person, and a rule that guessed at it would
+launder a judgement as a measurement. Where the reading is what matters, this abstains and
+says so.
+
+THE RULE, v2
+
+  recorded            a `confirms` edge exists, and if the prediction enumerates conjuncts,
+                      there are at least as many outcome edges as conjuncts.
+  unrecorded          `tests` edges exist, no `confirms`. The outcome is not in the graph.
+  untested            nothing points at it at all.
+  abstain:conjunction the prediction enumerates more commitments than it has edges, so no
+                      single verdict can be right about all of them.
+  abstain:convention  `confirms` without `tests`. Two conventions are in use in this corpus
+                      and this prediction follows the other one; which is correct is the
+                      question this layer asks, so the rule must not assume an answer.
+
+v1 of the rule matched enumerated conjuncts by roman numeral only and found 4. v2 adds
+`(a)(b)(c)` and finds 6 -- the two it had missed include the largest conjunction in the
+corpus, a four-part prediction with nine testing results. The version is recorded in the
+manifest because an approval is granted to a rule version, not to a rule.
+
+Usage:
+  python3 scripts/prediction_outcome.py                 # summary across the corpus
+  python3 scripts/prediction_outcome.py --write         # regenerate the manifest
+  python3 scripts/prediction_outcome.py --bucket unrecorded   # list one bucket
+  python3 scripts/prediction_outcome.py <paper-slug>
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from export_mira import CLAIMS_DIR, load_paper, public_papers, relations  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST = os.path.join(ROOT, "review", "prediction-outcome.json")
+
+RULE_VERSION = 2
+
+# An outcome edge says how a test came out. `confirms` is the only one that exists; the
+# absence of a negative counterpart is the finding, not an oversight in this list.
+OUTCOME = {"confirms"}
+NEUTRAL = {"tests"}
+
+# Predictions enumerate their commitments two ways. v1 knew only the first.
+ENUMERATORS = (
+    re.compile(r"\((i{1,3}|iv|v)\)"),
+    re.compile(r"\(([a-e])\)"),
+)
+
+BUCKETS = {
+    "recorded": (
+        "The graph says how the test came out. A `confirms` edge points at the prediction "
+        "from the result that settled it."),
+    "unrecorded": (
+        "A result is wired to the prediction with `tests`, which is neutral, and nothing "
+        "records the outcome. The paper asserts the result, so a reader would infer the "
+        "prediction was met -- but that inference is the reader's, not the graph's."),
+    "untested": (
+        "Nothing points at this prediction at all. It was derived from a hypothesis and then "
+        "left unconnected to any result."),
+    "abstain:conjunction": (
+        "The prediction states more commitments than it has edges -- \"should show (i)... "
+        "(ii)... (iii)...\" with fewer results wired than parts. One verdict cannot be right "
+        "about all of them, so the rule declines rather than picking the majority."),
+    "abstain:convention": (
+        "`confirms` without `tests`. Two conventions for wiring outcomes are in use across "
+        "this corpus, and this prediction follows the one that omits the neutral edge. Which "
+        "is correct is the question this layer asks, so the rule must not assume an answer."),
+}
+
+
+def conjuncts(text: str) -> list[str]:
+    """Enumerated commitments in a prediction's own words, by whichever scheme it used."""
+    for pat in ENUMERATORS:
+        found = sorted(set(m.lower() for m in pat.findall(text)))
+        if len(found) >= 2:
+            return found
+    return []
+
+
+def classify(pred: dict, incoming: dict[str, list[str]]) -> tuple[str, dict]:
+    """Bucket one prediction, and return the evidence the bucket was chosen on."""
+    tests = sorted(incoming.get("tests", []))
+    confirms = sorted(incoming.get("confirms", []))
+    parts = conjuncts(pred.get("claim", "") or "")
+    ev = {"tests": tests, "confirms": confirms, "conjuncts": parts}
+
+    if confirms and not tests:
+        return "abstain:convention", ev
+    if parts and max(len(tests), len(confirms)) < len(parts):
+        return "abstain:conjunction", ev
+    if confirms:
+        return "recorded", ev
+    if tests:
+        return "unrecorded", ev
+    return "untested", ev
+
+
+def scan(slugs: list[str]) -> list[dict]:
+    """Every prediction in these papers, bucketed. Order is stable so the manifest diffs."""
+    items = []
+    for paper in slugs:
+        if not os.path.isdir(os.path.join(CLAIMS_DIR, paper)):
+            continue
+        claims = load_paper(paper)
+        incoming: dict[str, dict[str, list[str]]] = collections.defaultdict(
+            lambda: collections.defaultdict(list))
+        for c in claims:
+            for key, target in relations(c):
+                if key in OUTCOME or key in NEUTRAL:
+                    incoming[target][key].append(c["slug"])
+        for c in sorted(claims, key=lambda x: x["slug"]):
+            if c.get("role") != "prediction":
+                continue
+            bucket, ev = classify(c, incoming.get(c["slug"], {}))
+            items.append({
+                "paper": paper,
+                "prediction": c["slug"],
+                "bucket": bucket,
+                "claim": " ".join((c.get("claim") or "").split()),
+                **ev,
+            })
+    return items
+
+
+def conventions(items: list[dict]) -> dict[str, dict[str, int]]:
+    """Which wiring convention each paper used. The split is the finding."""
+    out: dict[str, collections.Counter] = collections.defaultdict(collections.Counter)
+    for it in items:
+        t, c = bool(it["tests"]), bool(it["confirms"])
+        name = ("tests+confirms" if t and c else "confirms only" if c
+                else "tests only" if t else "neither")
+        out[it["paper"]][name] += 1
+    return {p: dict(v) for p, v in sorted(out.items())}
+
+
+def build(slugs: list[str]) -> dict:
+    items = scan(slugs)
+    counts = collections.Counter(i["bucket"] for i in items)
+    return {
+        "layer": "prediction-outcome",
+        "rule_version": RULE_VERSION,
+        "papers": len(slugs),
+        "predictions": len(items),
+        "buckets": {b: counts.get(b, 0) for b in BUCKETS},
+        "bucket_notes": BUCKETS,
+        "conventions": conventions(items),
+        "items": items,
+    }
+
+
+def write(data: dict) -> bool:
+    """Write the manifest. Returns whether anything changed, so a no-op run is visibly a
+    no-op rather than a fresh timestamp on identical content."""
+    os.makedirs(os.path.dirname(MANIFEST), exist_ok=True)
+    new = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    old = None
+    if os.path.isfile(MANIFEST):
+        with open(MANIFEST, encoding="utf-8") as fh:
+            old = fh.read()
+    if old == new:
+        return False
+    with open(MANIFEST, "w", encoding="utf-8") as fh:
+        fh.write(new)
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("paper", nargs="?")
+    ap.add_argument("--write", action="store_true", help="regenerate review/prediction-outcome.json")
+    ap.add_argument("--bucket", help="list the items in one bucket")
+    a = ap.parse_args()
+
+    slugs = [a.paper] if a.paper else public_papers()
+    data = build(slugs)
+
+    if a.write:
+        changed = write(data)
+        print(f"{MANIFEST}: {'updated' if changed else 'unchanged'} "
+              f"(rule v{RULE_VERSION}, {data['predictions']} predictions)")
+
+    if a.bucket:
+        for it in data["items"]:
+            if it["bucket"] != a.bucket:
+                continue
+            print(f"\n{it['paper']} :: {it['prediction']}")
+            print(f"  tests={it['tests'] or '—'}")
+            print(f"  confirms={it['confirms'] or '—'}")
+            if it["conjuncts"]:
+                print(f"  conjuncts={it['conjuncts']}")
+        return 0
+
+    print(f"rule v{RULE_VERSION} · {data['predictions']} predictions "
+          f"across {data['papers']} papers\n")
+    for b in BUCKETS:
+        n = data["buckets"][b]
+        bar = "█" * n
+        print(f"  {b:22s} {n:3d}  {bar}")
+    print("\nwiring convention by paper")
+    for p, d in data["conventions"].items():
+        if d:
+            print(f"  {p:34s} {d}")
+    abst = sum(v for k, v in data["buckets"].items() if k.startswith("abstain"))
+    print(f"\n{abst} abstention(s) — the rule declines these rather than guessing")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/components/LayerHeader.astro
+++ b/site/src/components/LayerHeader.astro
@@ -35,6 +35,10 @@ const code = (s: string) => s.replace(/`([^`]+)`/g, '<code class="text-[13px]">$
   <div class="flex flex-wrap items-baseline gap-3 mb-2">
     <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0">{layer.title}</h1>
     <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{layer.kind} · {layer.scope}</span>
+    {layer.status === 'proposed' && (
+      <span class="text-xs font-mono uppercase tracking-wider px-1.5 py-0.5 rounded border border-dashed border-amber-500 text-amber-700 dark:text-amber-400"
+            title="This layer's declaration is a proposal. It runs, but nothing about it has been accepted.">provisional</span>
+    )}
     {layer.open && <span class="text-xs font-mono uppercase tracking-wider text-blue-700 dark:text-blue-400">undecided</span>}
     {layer.requires_human && <span class="text-xs font-mono uppercase tracking-wider text-amber-700 dark:text-amber-400">needs a person</span>}
   </div>

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -29,7 +29,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 3,
+      "review_n": 8,
       "review_pending": 3,
       "tree": true,
       "verification": true,
@@ -59,7 +59,7 @@
       "formats": true,
       "marked": true,
       "review": true,
-      "review_n": 4,
+      "review_n": 8,
       "review_pending": 4,
       "tree": true,
       "verification": true,
@@ -74,7 +74,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 2,
+      "review_n": 8,
       "review_pending": 2,
       "tree": true,
       "verification": true,
@@ -89,7 +89,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 1,
+      "review_n": 5,
       "review_pending": 1,
       "tree": true,
       "verification": false,
@@ -104,7 +104,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 10,
+      "review_n": 12,
       "review_pending": 10,
       "tree": true,
       "verification": true,
@@ -119,7 +119,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 3,
+      "review_n": 5,
       "review_pending": 3,
       "tree": true,
       "verification": false,
@@ -134,7 +134,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 3,
+      "review_n": 7,
       "review_pending": 3,
       "tree": true,
       "verification": true,
@@ -149,7 +149,7 @@
       "formats": true,
       "marked": false,
       "review": true,
-      "review_n": 4,
+      "review_n": 13,
       "review_pending": 4,
       "tree": true,
       "verification": true,
@@ -377,6 +377,32 @@
         "question": "Does `epistemic` record support strength, or restate the role?",
         "scope": "corpus",
         "title": "Epistemic vocabulary",
+        "views": [
+          "table"
+        ]
+      },
+      {
+        "added": "2026-09-11",
+        "command": "python3 scripts/prediction_outcome.py --write",
+        "found": "`tests` is neutral by design, so a tree can record that a prediction was tested and never whether it was met. Of {{prediction_outcome_total}} predictions, {{prediction_outcome_unrecorded}} carry a `tests` edge and no outcome at all. Three wiring conventions are in use and they split by paper, not by case. And the vocabulary is asymmetric: `confirms` exists, nothing means \"the result came out against this\", so a failed prediction cannot be written down.\n",
+        "id": "prediction-outcome",
+        "issue": 28,
+        "kind": "question",
+        "needs": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "open": true,
+        "produces": [
+          "review/prediction-outcome.json"
+        ],
+        "question": "Did the paper's predictions come out, and does the tree say so?",
+        "reads": [
+          "scripts/prediction_outcome.py"
+        ],
+        "scope": "corpus",
+        "status": "proposed",
+        "title": "Prediction outcomes",
         "views": [
           "table"
         ]
@@ -8787,6 +8813,10 @@
           ],
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -8911,6 +8941,10 @@
             "stance"
           ],
           "v": 1
+        },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
         },
         "reconcile": {
           "state": "absent",
@@ -9042,6 +9076,10 @@
             "stance"
           ],
           "v": 1
+        },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
         },
         "reconcile": {
           "state": "absent",
@@ -9184,6 +9222,10 @@
           "ran": "2026-09-11T08:12:34Z",
           "state": "current",
           "v": 1
+        },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
         },
         "reconcile": {
           "by": "unrecorded",
@@ -9335,6 +9377,10 @@
           ],
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -9466,6 +9512,10 @@
           ],
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -9587,6 +9637,10 @@
           "ran": "2026-09-11T08:12:34Z",
           "state": "current",
           "v": 1
+        },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
         },
         "reconcile": {
           "state": "absent",
@@ -9722,6 +9776,10 @@
           "state": "current",
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -9853,6 +9911,10 @@
           ],
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -9978,6 +10040,10 @@
           "state": "current",
           "v": 1
         },
+        "prediction-outcome": {
+          "scope": "corpus",
+          "state": "open"
+        },
         "reconcile": {
           "state": "absent",
           "unrecorded_upstream": [
@@ -10019,6 +10085,56 @@
         }
       }
     }
+  },
+  "prediction_outcome": {
+    "abstained": 6,
+    "buckets": {
+      "abstain:conjunction": 1,
+      "abstain:convention": 5,
+      "recorded": 8,
+      "unrecorded": 27,
+      "untested": 5
+    },
+    "convention_kinds": 4,
+    "conventions": {
+      "bouyeure-2026-fear-rsa": {
+        "tests only": 5
+      },
+      "gadeke-2026-guilt-insula": {
+        "tests only": 4
+      },
+      "headley-2026-inhibitory-rhythms": {
+        "tests only": 6
+      },
+      "kammer-2026-foveal-feedback": {
+        "tests only": 4
+      },
+      "kolb-2026-igabasnfr2": {
+        "tests only": 2
+      },
+      "meijer-2025-serotonin-additive-r1": {
+        "confirms only": 3,
+        "neither": 3
+      },
+      "meijer-2025-serotonin-orthogonal": {
+        "confirms only": 2,
+        "neither": 2
+      },
+      "rozak-2026-neurovascular-dl": {
+        "tests only": 2
+      },
+      "scheller-2026-self-prioritization": {
+        "tests only": 4
+      },
+      "wengert-2026-kcnc1": {
+        "tests+confirms": 9
+      }
+    },
+    "recorded": 8,
+    "rule_version": 2,
+    "total": 46,
+    "unrecorded": 27,
+    "untested": 5
   },
   "relation_counts": {
     "confirms": 69,

--- a/site/src/lib/pipeline.ts
+++ b/site/src/lib/pipeline.ts
@@ -29,6 +29,11 @@ export interface LayerDecl {
   views?: string[];
   command?: string;
   issue?: number;
+  /** Lifecycle of the declaration itself (#31). A layer's declaration is a proposal: it says
+   *  a step should exist and what it does, and at some point that is accepted. Absent means
+   *  unstated — not accepted. Only `proposed` is rendered, so an undeclared status never
+   *  claims an approval nobody granted. */
+  status?: 'proposed' | 'accepted' | 'superseded';
   open?: boolean;
   requires_human?: boolean;
   added?: string;

--- a/site/src/pages/pipeline/prediction-outcome.astro
+++ b/site/src/pages/pipeline/prediction-outcome.astro
@@ -1,0 +1,291 @@
+---
+// Prediction outcomes — a proposed layer.
+//
+// The declaration is a proposal (#31): it says this step should exist and what it does, and
+// nothing about it has been accepted. So this page is not a decision queue. It exposes a rule,
+// what that rule does to the whole corpus, and where it refuses to decide — because the thing
+// being reviewed is the machinery, not forty-six individual judgements. A reviewer who had to
+// settle every item before anything could move would be a bottleneck by construction, which is
+// the mistake the relation-vocab queue already made.
+//
+// Reads review/prediction-outcome.json from the repository root rather than a copy under
+// src/data: the manifest is the layer's output, and a second copy is a second answer waiting
+// to drift from the first.
+import Layout from '../../layouts/Layout.astro';
+import LayerHeader from '../../components/LayerHeader.astro';
+import LayerState from '../../components/LayerState.astro';
+import { byId } from '../../lib/pipeline';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const layer = byId['prediction-outcome'];
+const m = JSON.parse(readFileSync(
+  join(process.cwd(), '..', 'review', 'prediction-outcome.json'), 'utf8'));
+
+const items = m.items as any[];
+const B = m.buckets as Record<string, number>;
+const NOTES = m.bucket_notes as Record<string, string>;
+const ORDER = ['recorded', 'unrecorded', 'untested', 'abstain:conjunction', 'abstain:convention'];
+const total = m.predictions as number;
+const abstained = ORDER.filter(b => b.startsWith('abstain')).reduce((n, b) => n + (B[b] ?? 0), 0);
+
+const inBucket = (b: string) => items.filter(i => i.bucket === b);
+const abstentions = items.filter(i => i.bucket.startsWith('abstain'));
+const short = (s: string, n = 230) => (s.length > n ? s.slice(0, n).trimEnd() + '…' : s);
+
+// The confident middle, sampled. One per paper so the sample spans the corpus rather than
+// showing four variations of the same paper's house style.
+const seen = new Set<string>();
+const unrecordedSample = inBucket('unrecorded').filter(i => {
+  if (seen.has(i.paper)) return false;
+  seen.add(i.paper);
+  return true;
+});
+
+const conventions = Object.entries(m.conventions as Record<string, Record<string, number>>)
+  .filter(([, v]) => Object.keys(v).length > 0);
+const CONV_ORDER = ['tests only', 'tests+confirms', 'confirms only', 'neither'];
+
+const pct = (n: number) => Math.round((n / total) * 100);
+const BAR: Record<string, string> = {
+  recorded: 'bg-emerald-500 dark:bg-emerald-600',
+  unrecorded: 'bg-amber-500 dark:bg-amber-600',
+  untested: 'bg-gray-400 dark:bg-gray-600',
+  'abstain:conjunction': 'bg-blue-400 dark:bg-blue-600',
+  'abstain:convention': 'bg-blue-400 dark:bg-blue-600',
+};
+---
+
+<Layout title="Prediction outcomes — pipeline"
+        description="A proposed layer: did the paper's predictions come out, and does the tree say so?">
+  <div class="max-w-4xl mx-auto px-4 sm:px-6 py-12">
+    <LayerHeader layer={layer} />
+
+    <!-- What is being asked of a reader. First, because it changes how everything below is read. -->
+    <section class="mb-10 border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 rounded-lg p-5">
+      <h2 class="text-[10px] font-mono uppercase tracking-wider text-amber-800 dark:text-amber-400 m-0 mb-2">
+        This layer is proposed, and what is proposed is the rule
+      </h2>
+      <p class="text-[15px] text-gray-800 dark:text-gray-200 m-0 mb-3 leading-relaxed">
+        Nothing on this page has been accepted, and no claim in the corpus has been changed by
+        it. What is offered for review is a <strong>rule</strong> and its behaviour across all
+        {total} predictions in the corpus — not {total} decisions to be taken one at a time.
+      </p>
+      <p class="text-[15px] text-gray-700 dark:text-gray-300 m-0 leading-relaxed">
+        So the useful way to read it is: does the rule sort these correctly, does it refuse the
+        cases it should refuse, and would applying it leave the corpus in a better state than it
+        is now? The {abstained} abstentions are listed in full below, because a rule that
+        declines what it cannot settle is what makes reviewing a sample sufficient — attention
+        goes to the margin instead of the confident middle.
+      </p>
+    </section>
+
+    <!-- The question, assuming nothing. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">The question</h2>
+    <div class="space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-8 max-w-2xl">
+      <p>
+        A prediction is a commitment made in advance: <em>if this hypothesis holds, then this
+        particular measurement should come out this particular way</em>. It is the part of a
+        paper's argument that can fail, which is what makes it worth recording separately from
+        the result that tests it.
+      </p>
+      <p>
+        In this corpus a result is joined to the prediction it bears on by a relation called
+        <code>tests</code>. <code>tests</code> is <strong>neutral by design</strong> — it
+        records that a test happened, not which way it came out. That neutrality is correct: the
+        two facts are genuinely different, and collapsing them would make every test look like a
+        success.
+      </p>
+      <p>
+        The problem is that nothing else records the outcome either. There is a positive
+        relation, <code>confirms</code>, used {items.filter(i => i.confirms.length).length} times
+        on predictions here. There is <strong>no negative counterpart</strong>. The two
+        oppositional relations do not fill the gap: <code>contradicts</code> and
+        <code>rules-out</code> both assert the target <em>is false</em>, and a refuted prediction
+        is not a false statement — it was a correct derivation from its hypothesis, and the
+        failure damages the hypothesis one edge upstream, not the prediction.
+      </p>
+      <p class="text-gray-900 dark:text-gray-100">
+        So the corpus can record that a prediction succeeded and cannot record that one failed.
+        Every tree published from it will look like a paper whose predictions all worked out.
+      </p>
+    </div>
+
+    <!-- The rule, inspectable as a rule. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">The rule</h2>
+    <p class="text-gray-600 dark:text-gray-400 text-sm mb-4 max-w-2xl">
+      It classifies each prediction by the <strong>shape of the graph around it</strong> — which
+      edges point at it, and whether the prediction's own words enumerate more commitments than
+      it has edges. It does <em>not</em> judge whether a result actually matches the prediction
+      it is wired to. That is a reading, it needs a person or an agent, and a rule that guessed
+      at it would launder a judgement as a measurement.
+    </p>
+    <div class="overflow-x-auto mb-10">
+      <table class="w-full text-sm border-collapse">
+        <thead>
+          <tr class="border-b border-gray-300 dark:border-gray-600">
+            <th class="text-left py-2 pr-3 font-mono text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">Bucket</th>
+            <th class="text-right py-2 px-3 font-mono text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 w-16">n</th>
+            <th class="text-left py-2 pl-3 font-mono text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">What it means</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ORDER.map(b => (
+            <tr class="border-b border-gray-100 dark:border-gray-800 align-top">
+              <td class="py-2.5 pr-3"><code class="text-[12.5px] whitespace-nowrap">{b}</code></td>
+              <td class="py-2.5 px-3 text-right font-mono tabular-nums text-gray-900 dark:text-gray-100">{B[b] ?? 0}</td>
+              <td class="py-2.5 pl-3 text-gray-700 dark:text-gray-300 leading-snug">{NOTES[b]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Corpus-wide behaviour. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">What it does to the whole corpus</h2>
+    <div class="mb-3 flex h-7 w-full overflow-hidden rounded border border-gray-200 dark:border-gray-700">
+      {ORDER.filter(b => (B[b] ?? 0) > 0).map(b => (
+        <div class={`${BAR[b]} flex items-center justify-center`} style={`width:${pct(B[b])}%`}
+             title={`${b}: ${B[b]}`}>
+          <span class="text-[10px] font-mono text-white/90">{B[b]}</span>
+        </div>
+      ))}
+    </div>
+    <p class="text-sm text-gray-600 dark:text-gray-400 mb-10 max-w-2xl">
+      {B['unrecorded']} of {total} predictions — {pct(B['unrecorded'])}% — are tested by a result
+      the paper asserts and carry no outcome at all. A reader of the graph can see that each was
+      tested and cannot see that any of them was met.
+    </p>
+
+    <!-- The finding that the model handles and a per-item queue could not. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Three conventions, splitting by paper</h2>
+    <p class="text-gray-600 dark:text-gray-400 text-sm mb-4 max-w-2xl">
+      This is not a gap in the format. The format can express an outcome, one paper does it for
+      every one of its predictions, another uses <code>confirms</code> <em>instead of</em>
+      <code>tests</code>, and seven never record one. Nobody reconciled them, and no check
+      notices. It is per-paper variation in how a corpus-level convention was applied — so
+      approving one paper's tree is evidence about a convention another paper's tree silently
+      violates.
+    </p>
+    <div class="overflow-x-auto mb-10">
+      <table class="w-full text-sm border-collapse">
+        <thead>
+          <tr class="border-b border-gray-300 dark:border-gray-600">
+            <th class="text-left py-2 pr-3 font-mono text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">Paper</th>
+            {CONV_ORDER.map(c => (
+              <th class="text-right py-2 px-3 font-mono text-[11px] tracking-wider text-gray-500 dark:text-gray-400 whitespace-nowrap">{c}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {conventions.map(([paper, counts]) => (
+            <tr class="border-b border-gray-100 dark:border-gray-800">
+              <td class="py-2 pr-3 font-mono text-[12px] text-gray-700 dark:text-gray-300">{paper}</td>
+              {CONV_ORDER.map(c => (
+                <td class="py-2 px-3 text-right font-mono tabular-nums text-gray-900 dark:text-gray-100">
+                  {counts[c] ?? <span class="text-gray-300 dark:text-gray-700">·</span>}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Where the rule refuses. This is where a reviewer's attention belongs. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Where the rule declines ({abstained})</h2>
+    <p class="text-gray-600 dark:text-gray-400 text-sm mb-4 max-w-2xl">
+      Listed in full, because they are the whole argument for trusting the rest. A rule that
+      produced a verdict for all {total} would be guessing on these.
+    </p>
+    <div class="space-y-3 mb-10">
+      {abstentions.map(i => (
+        <div class="border border-blue-200 dark:border-blue-900 rounded-lg p-4 bg-blue-50/40 dark:bg-blue-950/20">
+          <div class="flex flex-wrap items-baseline gap-2 mb-1.5">
+            <code class="text-[12px] text-gray-900 dark:text-gray-100">{i.prediction}</code>
+            <span class="font-mono text-[10px] uppercase tracking-wider text-blue-700 dark:text-blue-400">{i.bucket}</span>
+            <span class="text-[11px] text-gray-500 dark:text-gray-400 ml-auto font-mono">{i.paper}</span>
+          </div>
+          <p class="text-[13.5px] text-gray-700 dark:text-gray-300 m-0 mb-2 leading-snug">{short(i.claim)}</p>
+          <p class="text-[11.5px] font-mono text-gray-500 dark:text-gray-400 m-0">
+            tests: {i.tests.length ? i.tests.join(', ') : '—'}
+            <span class="mx-2">·</span>
+            confirms: {i.confirms.length ? i.confirms.join(', ') : '—'}
+            {i.conjuncts.length > 0 && <span><span class="mx-2">·</span>states {i.conjuncts.length} commitments ({i.conjuncts.join(' ')})</span>}
+          </p>
+        </div>
+      ))}
+    </div>
+
+    <!-- The confident middle, sampled so it can be spot-checked. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">The confident middle, sampled</h2>
+    <p class="text-gray-600 dark:text-gray-400 text-sm mb-4 max-w-2xl">
+      One <code>unrecorded</code> case per paper, so the sample spans the corpus rather than
+      showing several variations of one paper's house style. If the rule is wrong about these it
+      is wrong about {B['unrecorded']} claims.
+    </p>
+    <div class="space-y-3 mb-10">
+      {unrecordedSample.map(i => (
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <div class="flex flex-wrap items-baseline gap-2 mb-1.5">
+            <code class="text-[12px] text-gray-900 dark:text-gray-100">{i.prediction}</code>
+            <span class="text-[11px] text-gray-500 dark:text-gray-400 ml-auto font-mono">{i.paper}</span>
+          </div>
+          <p class="text-[13.5px] text-gray-700 dark:text-gray-300 m-0 mb-2 leading-snug">{short(i.claim)}</p>
+          <p class="text-[11.5px] font-mono text-gray-500 dark:text-gray-400 m-0">
+            tested by {i.tests.join(', ')} <span class="mx-2">·</span> outcome not recorded
+          </p>
+        </div>
+      ))}
+    </div>
+
+    <!-- Why acceptance attaches to a version. Demonstrated, not asserted. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">The rule has a version, and that is the point</h2>
+    <div class="space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-4 max-w-2xl">
+      <p>
+        The manifest records <code>rule_version: {m.rule_version}</code>, because an approval is
+        granted to a rule at a version and not to a rule in general. The first version of this
+        one was wrong in a way worth showing.
+      </p>
+      <p>
+        v1 detected an enumerated conjunction — a prediction that commits to several things at
+        once — by looking for roman numerals, and found four. v2 also matches
+        <code>(a)(b)(c)</code> and finds six. The two it had been missing include the largest
+        conjunction in the corpus: a four-part prediction wired to nine testing results. Under
+        v1 that prediction was silently classified as though it made a single commitment.
+      </p>
+      <p>
+        Nothing about v1 looked broken. It ran, it produced a plausible number, and the only way
+        to catch it was to look at what it did across the corpus and notice that a prediction
+        with nine testers had not been flagged. That is the argument for reviewing behaviour in
+        aggregate rather than approving items one by one: the items all looked fine.
+      </p>
+    </div>
+
+    <!-- What is still undecided. Honest about what this layer cannot settle by itself. -->
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">What accepting this would not settle</h2>
+    <div class="space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-10 max-w-2xl">
+      <p>
+        This layer can say which predictions have no recorded outcome. It cannot supply the
+        outcomes, and it cannot record a failure, because the vocabulary has nowhere to put one.
+        That decision belongs to the relation vocabulary and is genuinely open: adding a
+        <code>refutes</code> relation under <code>mira:opposes</code> would assert that a
+        refuted prediction is <em>false</em>, which is not what happened to it, and the relation
+        checker already rejects edges that oppose a claim their own paper asserts.
+      </p>
+      <p>
+        There is a separate defect this layer makes visible without being able to fix. In the
+        MIRA export, <code>tests</code> is declared a subclass of <code>mira:supports</code>. So
+        every <code>tests</code> edge reaches eLife as a <strong>supporting</strong> relation:
+        the tree declines to say how a test came out, and the export answers anyway.
+      </p>
+    </div>
+
+    <LayerState layer={layer} />
+
+    <footer class="pt-6 border-t border-gray-100 dark:border-gray-800 text-sm">
+      <a href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/pipeline/`}
+         class="text-gray-500 dark:text-gray-400 no-underline hover:text-gray-700 dark:hover:text-gray-300">← all layers</a>
+    </footer>
+  </div>
+</Layout>


### PR DESCRIPTION
Refs #28, #31. First layer declared `status: proposed` under the model in #31 — the declaration is a proposal, it runs, and nothing about it has been accepted.

**Page:** `/pipeline/prediction-outcome/`

## The finding

A prediction is the part of a paper's argument that can fail. This corpus records which result *tested* each one and, for most, never whether it was met.

`tests` is neutral by design, and that is correct. The problem is nothing else records the outcome either — **27 of 46 predictions carry a `tests` edge and nothing more.**

And the vocabulary is asymmetric. `confirms` exists; there is no negative counterpart. `contradicts`/`rules-out` don't fill the gap, because both assert the target *is false*, and a refuted prediction isn't a false statement — it was a correct derivation from its hypothesis, and the failure damages the hypothesis one edge upstream. **So the corpus can record that a prediction succeeded and cannot record that one failed.** Every tree we publish will look like a paper whose predictions all worked out.

## Three conventions, splitting by paper

Not a gap in the format — an unreconciled inconsistency no check notices:

| convention | predictions | papers |
|---|---|---|
| `tests` only, no outcome | 27 | bouyeure, gädeke, headley, kammer, kolb, rozak, scheller |
| `tests` + `confirms` | 9 | wengert only |
| `confirms` only, no `tests` | 5 | meijer (both) |
| neither | 5 | meijer (both) |

This is the case #31's model handles and a per-paper view could not: approving Wengert's tree is evidence about a convention Gädeke's tree silently violates.

## What is offered for review

The **rule and its behaviour across the corpus**, not 46 decisions. A reviewer who had to settle every item before anything moved would be a bottleneck by construction — which is what `review/dissociates-with.json` already is, with 45 pending items blocking its applier.

The rule classifies by graph shape only: `recorded` / `unrecorded` / `untested`, plus two abstentions — `abstain:conjunction` (the prediction enumerates more commitments than it has edges) and `abstain:convention` (`confirms` without `tests`). It does **not** judge whether a result matches the prediction it is wired to; that is a reading, and a rule that guessed at it would launder a judgement as a measurement. All 6 abstentions are listed in full on the page, because a rule that declines what it cannot settle is what makes reviewing a sample sufficient.

## Why the rule has a version

v1 detected enumerated conjunctions by roman numeral and found 4. v2 also matches `(a)(b)(c)` and finds 6. The two it had missed include the largest conjunction in the corpus — a four-part prediction wired to nine testing results, which v1 silently treated as a single commitment.

Nothing about v1 looked broken. It ran and produced a plausible number. That is the argument for reviewing aggregate behaviour rather than approving items, and it is on the page as the worked demonstration.

Once declarations are hashed inputs (#31 step 1), this is also a ready-made test case: bumping the rule version should turn every affected cell amber.

## Machinery

- `scripts/prediction_outcome.py` — detector, versioned rule, idempotent (`--write` reports `unchanged` on a no-op)
- `review/prediction-outcome.json` — the manifest, declared in `produces`
- `pipeline/layers.yaml` — the declaration, `needs: [claim-format, relation-vocab]`, `reads` the detector
- `status` added to `LayerDecl` and rendered as a dashed `provisional` marker. **Absent status means unstated, never accepted** — no existing layer is marked approved by this change.

The page reads the manifest from the repo root rather than a copy under `src/data`, so there is no second answer to drift.

## Not fixed here

`tests` is declared `subClassOf mira:supports` in `export_mira.py`, so all 73 `tests` edges reach eLife as **supporting** relations — the tree declines to say how a test came out and the export answers anyway. Surfaced on the page; the decision belongs to `relation-vocab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)