### PR TITLE
The site said 'verified' where it meant 'we re-ran it' (#27)

### DIFF
--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -19,75 +19,79 @@ const outFile = join(outDir, 'claims.json');
 mkdirSync(outDir, { recursive: true });
 
 // --- Verification level taxonomy ---
-// L1: metadata check (PDB record, deposit exists)
-// L2: CSV comparison (read deposited intermediates, compare to paper)
-// L3: re-execute scripts (run author code on deposited data)
-// L4: independent re-analysis (new code on deposited data)
-// L5: full pipeline (raw data → preprocessing → analysis → result)
+// How far we got re-running a paper. Every rung is a fact about our effort against the
+// authors' *deposited* material — none of it is replication, which would mean an independent
+// study finding the same thing, and which this corpus has never attempted.
+//
+// L1: we checked the deposit exists (a PDB record, a repository)
+// L2: we read the deposited intermediates and compared them to the paper
+// L3: we ran the authors' own scripts on their own data
+// L4: we wrote our own analysis and ran it on their deposited data
+// L5: we ran the whole pipeline from raw data — never reached
 const VERIFICATION_LEVELS = {
   'artiushin-2026-spider-atlas': {
     level: 'unverified',
-    label: 'Not attempted',
+    label: 'We have not attempted it',
     detail: 'Atlas paper — data on Brain Image Library, verification is image inspection. Not attempted in this prototype.',
   },
   'bouyeure-2026-fear-rsa': {
     level: 'L4',
-    label: 'Independent re-analysis',
+    label: 'We re-analysed their deposited data',
     detail: 'Downloaded NeuroVault NIfTI maps, independently counted significant voxels and found MNI peaks. Full MVPA pipeline not re-run.',
   },
   'ejdrup-2026-dopamine': {
     level: 'L3',
-    label: 'Re-executed scripts',
+    label: 'We ran their deposited scripts',
     detail: 'Ran deposited figure-generation scripts with matplotlib patch. Vmax parameter sweep timed out (600s) — 3 simulation claims unverified.',
   },
   'gadeke-2026-guilt-insula': {
     level: 'L4',
-    label: 'Independent re-analysis',
+    label: 'We re-analysed their deposited data',
     detail: 'Downloaded OpenNeuro CSVs, fit logistic regression independently, confirmed MNI peak coordinates. Full fMRI preprocessing not re-run.',
   },
   'headley-2026-inhibitory-rhythms': {
     level: 'L2',
-    label: 'CSV comparison',
+    label: 'We compared their deposited CSVs',
     detail: 'Read deposited CSVs from GitHub, confirmed firing-rate values and STA timings. NEURON simulation not re-run (6 hrs + 1.88 GB Dryad).',
   },
   'kammer-2026-foveal-feedback': {
     level: 'unverified',
-    label: 'Compute-infeasible',
+    label: 'We could not re-run it — specialist compute',
     detail: 'Per-subject fMRI MVPA pipeline requires specialist compute. Data on OpenNeuro but pipeline not re-run.',
   },
   'kolb-2026-igabasnfr2': {
     level: 'L1',
-    label: 'Metadata check',
+    label: 'We checked the deposit exists',
     detail: 'Parsed PDB 9D57 record from RCSB, confirmed structure metadata. Wet-lab experiments not computationally reproducible.',
   },
   'meijer-2025-serotonin-additive-r1': {
     level: 'L2',
-    label: 'CSV comparison',
+    label: 'We compared their deposited CSVs',
     detail: 'Read deposited CSVs from GitHub repo, confirmed GLM interaction, modulation counts, and receptor expression results. 14/14 PASS. Full GLM refit requires iblatlas.',
   },
   'meijer-2025-serotonin-orthogonal': {
     level: 'L2',
-    label: 'CSV comparison',
+    label: 'We compared their deposited CSVs',
     detail: 'Read deposited CSVs from GitHub repo, confirmed neuron counts, modulation fractions, and orthogonality measures. 9/12 PASS, 2 FAIL (ripple suppression direction, region count), 1 WARN (latency correlation).',
   },
   'rozak-2026-neurovascular-dl': {
     level: 'unverified',
-    label: 'Training data proprietary',
+    label: 'We could not re-run it — training data is proprietary',
     detail: 'Deep learning pipeline trained on proprietary microscopy data. Pre-trained model available but training set not redistributable.',
   },
   'sautory-2026-serotonin-novelty': {
     level: 'L2',
-    label: 'CSV comparison + repo audit',
+    label: 'We compared their CSVs and audited the repo',
     detail: 'All statistical values verified against deposited CSVs. Analysis scripts and data paths confirmed on disk. Full R analysis pipeline not re-run.',
   },
   'scheller-2026-self-prioritization': {
     level: 'L2',
-    label: 'CSV comparison',
+    label: 'We compared their deposited CSVs',
     detail: 'Downloaded Stan posterior CSVs from OSF (live, not from-notes). Computed TVA statistics from posterior samples. 8/8 PASS. Full Stan model not re-run (12 hrs).',
   },
   'wengert-2026-kcnc1': {
     level: 'L4',
-    label: 'Independent re-analysis',
+    label: 'We re-analysed their deposited data',
     detail: 'Downloaded G-Node Excel data, computed independent statistical tests. Direction confirmed for all claims; one magnitude mismatch (maximal firing).',
   },
 };

--- a/site/src/components/ClaimCardMini.astro
+++ b/site/src/components/ClaimCardMini.astro
@@ -1,5 +1,5 @@
 ---
-import { STATUS_LABEL } from '../lib/status';
+import { outcomeOf, OUTCOME_SHORT, OUTCOME_LABEL, BLOCKED_REASON } from '../lib/status';
 
 type Claim = {
   slug: string;
@@ -45,27 +45,27 @@ const roleStyle: Record<string, string> = {
   scope:          'bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-800/60 dark:text-slate-300 dark:border-slate-700',
 };
 
-// Status dot color — role-aware palette
-function statusDot(status: string, role: string | null): { color: string; label: string } {
-  if (status === 'verified') return { color: '#22c55e', label: STATUS_LABEL[status] ?? status };
-  if (status?.startsWith('verified:')) return { color: '#86efac', label: STATUS_LABEL[status] ?? status };
-  if (status === 'failed' || status?.startsWith('unverified:code-error') || status?.startsWith('unverified:compute-infeasible')) {
-    return { color: '#f59e0b', label: STATUS_LABEL[status] ?? status };
-  }
-  // Role-based colors for claims that don't get code verification
-  if (status === 'unknown' || !status) {
-    if (role === 'hypothesis' || role === 'prediction') return { color: '#60a5fa', label: role };
-    if (role === 'literature-context') return { color: '#a78bfa', label: 'cited claim' };
-    if (role === 'synthesis' || role === 'interpretation') return { color: '#60a5fa', label: role };
-  }
-  return { color: '#9ca3af', label: STATUS_LABEL[status] ?? status ?? 'unknown' };
+// The dot is the paper's argument, not our run. It colours by role, which is what the claim
+// does in the paper — so with the reproduction chip off, the card carries no verdict of ours.
+function roleDot(role: string | null): { color: string; label: string } {
+  if (role === 'hypothesis' || role === 'prediction') return { color: '#60a5fa', label: role };
+  if (role === 'literature-context') return { color: '#a78bfa', label: 'cited claim' };
+  if (role === 'synthesis' || role === 'interpretation') return { color: '#60a5fa', label: role ?? '' };
+  if (role === 'scope' || role === 'methodological') return { color: '#94a3b8', label: role };
+  return { color: '#64748b', label: role ?? 'claim' };
 }
 
-const dot = statusDot(claim.status, claim.role);
+const dot = roleDot(claim.role);
+// What we did, if we did anything. `not-attempted` and `none` render nothing: an absence of
+// effort on our part is not a property of the claim and should not appear on its card.
+const outcome = outcomeOf(claim.status);
+const showRepro = outcome !== 'none' && outcome !== 'not-attempted';
+const reproTitle = outcome === 'blocked'
+  ? `We could not re-run this: ${BLOCKED_REASON[claim.status] ?? 'see the paper\u2019s verification record'}`
+  : `Our re-run of the authors\u2019 deposited code — ${OUTCOME_LABEL[outcome]}`;
 const claimText = (claim.displayClaim?.trim()) || claim.claim;
 const hasCode = !!claim.script;
 const hasFigure = !!claim.figureUrl;
-const isVerified = claim.status.startsWith('verified');
 
 // Recursive children (requires) for supporting-claims disclosure
 const children = (claim.requires ?? [])
@@ -78,7 +78,7 @@ const children = (claim.requires ?? [])
   data-claim-slug={claim.slug}
   id={`claim-card-${claim.slug}`}
 >
-  <div class={`claim-mini-card ${isVerified ? 'claim-mini-verified' : ''}`} data-claim-slug={claim.slug} tabindex="0" role="button" aria-label={`Open details for ${claim.slug}`}>
+  <div class="claim-mini-card" data-claim-slug={claim.slug} tabindex="0" role="button" aria-label={`Open details for ${claim.slug}`}>
     {/* Top row: number + role chip + panel ref + status dot + code/figure glyphs */}
     <div class="claim-mini-top">
       {claim.number && (
@@ -105,11 +105,12 @@ const children = (claim.requires ?? [])
         title={dot.label}
         aria-label={`Status: ${dot.label}`}
       />
-      {isVerified && (
-        <span class="mini-verified-badge" title="Verified" aria-label="Verified">✓ verified</span>
+      {showRepro && (
+        <span class={`mini-repro-chip mini-repro-${outcome}`} title={reproTitle}
+              aria-label={reproTitle}>{OUTCOME_SHORT[outcome]}</span>
       )}
-      {!isVerified && hasCode && (
-        <span class="mini-code-badge" title="Has verification code" aria-label="Has verification code">{ } code</span>
+      {!showRepro && hasCode && (
+        <span class="mini-code-badge" title="Deposited code is available to re-run" aria-label="Deposited code is available">{ } code</span>
       )}
     </div>
 
@@ -153,9 +154,6 @@ const children = (claim.requires ?? [])
     background: var(--card-bg);
     transition: border-color 0.12s ease, box-shadow 0.12s ease, background-color 0.12s ease;
     outline: none;
-  }
-  .claim-mini-verified {
-    border-left: 3px solid #22c55e;
   }
   .claim-mini-card:hover,
   .claim-mini-card:focus-visible {
@@ -219,17 +217,29 @@ const children = (claim.requires ?? [])
     display: inline-block;
     flex-shrink: 0;
   }
-  .mini-verified-badge {
+  /* A reproduction result is something we attached, so it reads as attached: a chip on the
+     card's edge in the tooling palette, never green. Green and red are the truth signal and
+     this is provenance. `differs` is the exception — a re-run that disagrees with the paper is
+     a finding, and worth a warm colour. */
+  .mini-repro-chip {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 9.5px;
-    font-weight: 600;
-    color: var(--ok-fg);
-    background: var(--ok-bg);
-    border: 1px solid var(--ok-border);
     padding: 0px 5px;
     border-radius: 3px;
     letter-spacing: 0.02em;
+    white-space: nowrap;
+    color: var(--repro-fg);
+    background: var(--repro-bg);
+    border: 1px solid var(--repro-border);
   }
+  .mini-repro-match   { --repro-fg: #334155; --repro-bg: #f1f5f9; --repro-border: #cbd5e1; }
+  .mini-repro-partial { --repro-fg: #475569; --repro-bg: #f8fafc; --repro-border: #e2e8f0; }
+  .mini-repro-blocked { --repro-fg: #64748b; --repro-bg: transparent; --repro-border: #e2e8f0; }
+  .mini-repro-differs { --repro-fg: #92400e; --repro-bg: #fef3c7; --repro-border: #fcd34d; }
+  :root[data-theme='dark'] .mini-repro-match   { --repro-fg: #cbd5e1; --repro-bg: #1e293b; --repro-border: #334155; }
+  :root[data-theme='dark'] .mini-repro-partial { --repro-fg: #94a3b8; --repro-bg: #1e293b99; --repro-border: #334155; }
+  :root[data-theme='dark'] .mini-repro-blocked { --repro-fg: #94a3b8; --repro-bg: transparent; --repro-border: #334155; }
+  :root[data-theme='dark'] .mini-repro-differs { --repro-fg: #fcd34d; --repro-bg: #451a03; --repro-border: #92400e; }
   .mini-code-badge {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 9.5px;

--- a/site/src/components/ClaimDAG.tsx
+++ b/site/src/components/ClaimDAG.tsx
@@ -16,7 +16,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import dagre from '@dagrejs/dagre';
-import { nodeColor } from '../lib/status';
+import { nodeColor, outcomeOf, OUTCOME_LABEL, OUTCOME_COLOR } from '../lib/status';
 
 interface Claim {
   slug: string;
@@ -43,7 +43,9 @@ function shortLabel(slug: string): string {
 
 // Custom node renderer
 function ClaimNode({ data }: { data: any }) {
-  const color = nodeColor(data.status, data.role);
+  // `repro` is the layer switch, handed down from the graph. Off — the default — the node
+  // is coloured by what the claim does in the paper, and the tree carries no verdict of ours.
+  const color = nodeColor(data.status, data.role, Boolean((data as any).repro));
   const isAssessment = data.isAssessment;
 
   return (
@@ -159,7 +161,16 @@ function DAGInner({ claims, paperSlug }: Props) {
   const [nodes, setNodes] = useNodesState(initialNodes);
   const [edges, setEdges] = useEdgesState(initialEdges);
   const [selected, setSelected] = useState<Claim | null>(null);
+  // Off by default: a reader arriving at a claim tree should see the paper's argument, not a
+  // scorecard of what we managed to re-run.
+  const [showRepro, setShowRepro] = useState(false);
   const { fitView } = useReactFlow();
+
+  // Repainting the whole graph when the layer is switched, rather than reading the flag from
+  // a context in each node — the node count here is small and this keeps the node dumb.
+  React.useEffect(() => {
+    setNodes(nds => nds.map(n => ({ ...n, data: { ...n.data, repro: showRepro } })));
+  }, [showRepro, setNodes]);
 
   // Build adjacency for highlighting
   const claimBySlug = useMemo(() => {
@@ -240,21 +251,37 @@ function DAGInner({ claims, paperSlug }: Props) {
           <Background color="#f3f4f6" gap={20} />
           <Controls />
           <MiniMap
-            nodeColor={(n) => nodeColor((n.data as any)?.status ?? 'unknown', (n.data as any)?.role)}
+            nodeColor={(n) => nodeColor((n.data as any)?.status ?? 'unknown', (n.data as any)?.role, showRepro)}
             style={{ background: '#f9fafb' }}
           />
           <Panel position="top-left">
             <div className="bg-white border border-gray-200 rounded-lg p-3 text-xs shadow-sm space-y-1.5">
-              <div className="font-semibold text-gray-700 mb-1">Status</div>
-              {[
-                ['#22c55e', 'Verified by code'],
-                ['#86efac', 'Partially verified'],
-                ['#ef4444', 'Failed / mismatch'],
-                ['#60a5fa', 'Hypothesis / prediction / synthesis'],
-                ['#a78bfa', 'Cited claim (literature)'],
-                ['#9ca3af', 'Unverified'],
-                ['#f97316', 'Code error / compute'],
-              ].map(([color, label]) => (
+              {/* The reproduction layer is a switch, and off by default. With it off the graph
+                  shows what the paper argues and nothing about what we ran — which is the test
+                  that the separation is real rather than described. */}
+              <label className="flex items-center gap-1.5 cursor-pointer select-none pb-1.5 mb-1 border-b border-gray-100">
+                <input type="checkbox" checked={showRepro}
+                       onChange={(e) => setShowRepro(e.target.checked)} className="accent-slate-600" />
+                <span className="font-semibold text-gray-700">Colour by our re-runs</span>
+              </label>
+              <div className="font-semibold text-gray-700 mb-1">
+                {showRepro ? 'What we re-ran' : "The paper's argument"}
+              </div>
+              {(showRepro
+                ? ([
+                    [OUTCOME_COLOR.match, OUTCOME_LABEL.match],
+                    [OUTCOME_COLOR.partial, OUTCOME_LABEL.partial],
+                    [OUTCOME_COLOR.differs, OUTCOME_LABEL.differs],
+                    [OUTCOME_COLOR.blocked, OUTCOME_LABEL.blocked],
+                    [OUTCOME_COLOR['not-attempted'], OUTCOME_LABEL['not-attempted']],
+                  ] as [string, string][])
+                : ([
+                    ['#60a5fa', 'Hypothesis / prediction / synthesis'],
+                    ['#a78bfa', 'Cited claim (literature)'],
+                    ['#64748b', 'Empirical result / control'],
+                    ['#94a3b8', 'Scope / methodological'],
+                  ] as [string, string][])
+              ).map(([color, label]) => (
                 <div key={label} className="flex items-center gap-1.5">
                   <span style={{ width: 10, height: 10, borderRadius: 2, background: color, display: 'inline-block' }} />
                   <span className="text-gray-600">{label}</span>
@@ -292,7 +319,7 @@ function DAGInner({ claims, paperSlug }: Props) {
             <div className="flex flex-wrap gap-1.5">
               <span
                 className="inline-block px-2 py-0.5 rounded text-xs font-medium"
-                style={{ background: nodeColor(selected.status, selected.role) + '22', color: '#111', border: `1px solid ${nodeColor(selected.status, selected.role)}` }}
+                style={{ background: nodeColor(selected.status, selected.role, showRepro) + '22', color: '#111', border: `1px solid ${nodeColor(selected.status, selected.role, showRepro)}` }}
               >{selected.status === 'unknown' ? selected.role : selected.status}</span>
               <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
                 {selected.epistemic}

--- a/site/src/components/ClaimDrawer.tsx
+++ b/site/src/components/ClaimDrawer.tsx
@@ -51,19 +51,29 @@ type Props = {
   baseUrl: string;
 };
 
+// What we did, in the first person — the same vocabulary as lib/status.ts. A drawer that
+// said "Verified" in green was the site's most direct claim that a proposition is true, on
+// the strength of having re-run a script.
 const STATUS_LABEL: Record<string, string> = {
-  verified: 'Verified',
-  failed: 'Failed',
-  'unverified:no-data': 'No data',
-  'unverified:no-code': 'No code',
-  unverified: 'Unverified',
-  'unverified:code-error': 'Code error',
-  'unverified:compute-infeasible': 'Compute-infeasible',
-  unknown: 'Unknown',
+  'verified': 're-ran: numbers match',
+  'verified:partial': 're-ran: partly matches',
+  'verified:with-nuance': 're-ran: matches, with nuance',
+  'verified:direction-and-trend': 're-ran: direction and trend match',
+  'verified:interpretive': 'checked by reading, not by running',
+  'failed': 're-ran: differs',
+  'failed:mismatch': 're-ran: differs',
+  'unverified:no-data': 'couldn\u2019t re-run — no data deposited',
+  'unverified:no-code': 'couldn\u2019t re-run — no code deposited',
+  'unverified:code-error': 'couldn\u2019t re-run — the deposited code errored',
+  'unverified:compute-infeasible': 'couldn\u2019t re-run — needs specialist compute',
+  'unverified:partial': 'not re-run yet',
+  'unverified': 'not re-run yet',
+  'unknown': 'not re-run yet',
 };
 
 function statusDotColor(status: string): string {
-  if (status === 'verified') return '#22c55e';
+  // Slate, not green. The dot says we re-ran something; green would say the claim is true.
+  if (status === 'verified') return '#475569';
   if (
     status === 'failed' ||
     status === 'unverified:code-error' ||
@@ -160,79 +170,79 @@ function verificationBanner(status: string, role?: string | null, stance?: strin
 
   // --- Code-executed verification statuses ---
   if (status === 'verified') return {
-    bg: '#f0fdf4', border: '#bbf7d0', text: '#166534', hue: 'green', icon: '✓',
+    bg: '#f8fafc', border: '#cbd5e1', text: '#334155', hue: 'slate', icon: '=',
     label: (role === 'scope' || role === 'methodological')
-      ? 'Confirmed by inspection'
-      : 'Verified by code',
+      ? 'we checked this by reading'
+      : 're-ran: numbers match',
     detail: (role === 'scope' || role === 'methodological')
-      ? 'Confirmed by reading the deposited code, methods text, or data records.'
-      : 'A verification script ran against the deposited data and reproduced this result.',
+      ? 'Someone read the deposited code, methods text or data records and found this to hold. Not a judgement of whether the claim is correct.'
+      : 'We ran a script against the authors\u2019 deposited data and the number that came out matched the number in the paper. That is a fact about the re-run, not about whether the claim is true.',
   };
   if (status === 'verified:partial') return {
-    bg: '#f0fdf4', border: '#d1fae5', text: '#166534', hue: 'green', icon: '~',
-    label: 'Partially verified',
-    detail: 'A subset of this claim was verified against deposited data; the remainder is documented in notes.',
+    bg: '#f8fafc', border: '#cbd5e1', text: '#334155', hue: 'slate', icon: '~',
+    label: 're-ran: partly matches',
+    detail: 'Part of this claim came back matching against the deposited data. What we could not re-run is in the notes.',
   };
   if (status === 'verified:with-nuance') return {
     bg: '#fffbeb', border: '#fde68a', text: '#92400e', hue: 'amber', icon: '~',
-    label: 'Verified with nuance',
-    detail: 'Direction or trend matches; magnitude or significance differs from the paper. Discrepancy documented.',
+    label: 're-ran: matches, with a discrepancy',
+    detail: 'Direction or trend came back matching; magnitude or significance differs from the paper. The discrepancy is documented below.',
   };
   if (status === 'verified:interpretive') return {
-    bg: '#f0fdf4', border: '#d1fae5', text: '#166534', hue: 'green', icon: '✓',
-    label: 'Verified by reasoning',
-    detail: 'This interpretive claim was confirmed by examining the evidence structure, not by running code.',
+    bg: '#f8fafc', border: '#cbd5e1', text: '#334155', hue: 'slate', icon: '=',
+    label: 'checked by reading, not by running',
+    detail: 'An interpretive claim with no code to run. Someone examined the evidence structure behind it — which is weaker evidence than a re-run, and is recorded separately for that reason.',
   };
   if (status === 'verified:direction-and-trend') return {
-    bg: '#f0fdf4', border: '#d1fae5', text: '#166534', hue: 'green', icon: '~',
-    label: 'Direction confirmed',
-    detail: 'The direction and trend match the paper; exact values differ.',
+    bg: '#f8fafc', border: '#cbd5e1', text: '#334155', hue: 'slate', icon: '~',
+    label: 're-ran: direction and trend match',
+    detail: 'The direction and trend came back matching the paper; exact values differ.',
   };
 
   // --- Failure ---
   if (status === 'failed' || status === 'failed:mismatch') return {
-    bg: '#fef2f2', border: '#fecaca', text: '#991b1b', hue: 'red', icon: '✗',
-    label: 'Result mismatch',
-    detail: 'The verification script ran on the deposited data and produced a different result than the paper reports.',
+    bg: '#fffbeb', border: '#fde68a', text: '#92400e', hue: 'amber', icon: '≠',
+    label: 're-ran: differs',
+    detail: 'We ran the authors\u2019 deposited code on their deposited data and got a different number than the paper reports. That is a disagreement worth looking at, not a verdict: it can be our error as easily as theirs.',
   };
 
   // --- Unverified with reason ---
   if (status === 'unverified:code-error') return {
     bg: '#fffbeb', border: '#fde68a', text: '#92400e', hue: 'amber', icon: '!',
-    label: 'Code error',
-    detail: 'A verification script exists but encountered an error during execution.',
+    label: 'couldn\u2019t re-run — the code errored',
+    detail: 'A script exists and we tried to run it, but it failed. Nothing follows about the claim.',
   };
   if (status === 'unverified:compute-infeasible') return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '⏱',
-    label: 'Compute-infeasible',
-    detail: 'Verification requires specialist hardware or long compute times beyond our current infrastructure.',
+    label: 'couldn\u2019t re-run — needs specialist compute',
+    detail: 'Re-running this needs hardware or compute time we do not have. Not attempted, rather than attempted and failed.',
   };
   if (status === 'unverified:no-data') return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '—',
-    label: 'No data deposited',
-    detail: 'The data needed to verify this claim is not publicly available.',
+    label: 'couldn\u2019t re-run — no data deposited',
+    detail: 'The data this claim rests on is not publicly available, so there is nothing to re-run it against.',
   };
   if (status === 'unverified:no-code') return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '—',
-    label: 'No verification code',
-    detail: 'No verification script has been written for this claim yet.',
+    label: 'not re-run yet — no script written',
+    detail: 'Nobody has written a script to re-run this one. A gap in our effort, not in the paper.',
   };
   if (status === 'unverified' || status === 'unverified:partial' || status.startsWith('partial')) return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '○',
-    label: 'Unverified',
-    detail: 'This empirical claim has not yet been verified against deposited data.',
+    label: 'not re-run yet',
+    detail: 'Nobody has attempted to re-run this claim against the deposited data. It says nothing about whether the claim holds.',
   };
   if (status === 'N/A') return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '—',
-    label: 'Not applicable',
-    detail: 'This claim is not the kind that can be verified by running code.',
+    label: 'nothing to re-run',
+    detail: 'This is not the kind of claim a script can check \u2014 a scope condition, or an interpretation.',
   };
 
   // --- Fallback ---
   return {
     bg: 'var(--card-sunk)', border: 'var(--card-border)', text: 'var(--card-muted)', icon: '?',
     label: status,
-    detail: 'Status not recognized — see notes for details.',
+    detail: 'We do not recognise this status \u2014 see the notes.',
   };
 }
 

--- a/site/src/components/ClaimTreeNode.astro
+++ b/site/src/components/ClaimTreeNode.astro
@@ -1,5 +1,5 @@
 ---
-import { STATUS_TAILWIND, EPISTEMIC_TAILWIND, STATUS_LABEL } from '../lib/status';
+import { EPISTEMIC_TAILWIND, outcomeOf, OUTCOME_SHORT, OUTCOME_TAILWIND } from '../lib/status';
 
 type Claim = {
   slug: string;
@@ -62,9 +62,11 @@ const cardBg = isSecondaryRoot
           {claimText}
         </p>
         <div class="flex items-center gap-2 flex-wrap mt-2">
-          <span class={`text-xs px-1.5 py-0.5 rounded ${STATUS_TAILWIND[claim.status] ?? 'bg-gray-50 text-gray-500'}`}>
-            {STATUS_LABEL[claim.status] ?? claim.status}
-          </span>
+          {outcomeOf(claim.status) !== 'none' && outcomeOf(claim.status) !== 'not-attempted' && (
+            <span class={`text-xs px-1.5 py-0.5 rounded ${OUTCOME_TAILWIND[outcomeOf(claim.status)]}`}>
+              {OUTCOME_SHORT[outcomeOf(claim.status)]}
+            </span>
+          )}
           <span class={`text-xs px-1.5 py-0.5 rounded ${EPISTEMIC_TAILWIND[claim.epistemic] ?? 'bg-gray-50 text-gray-500'}`}>
             {claim.epistemic}
           </span>

--- a/site/src/data/claims.json
+++ b/site/src/data/claims.json
@@ -20,7 +20,7 @@
         "verified": 2
       },
       "verificationLevel": "unverified",
-      "verificationLabel": "Not attempted",
+      "verificationLabel": "We have not attempted it",
       "verificationDetail": "Atlas paper — data on Brain Image Library, verification is image inspection. Not attempted in this prototype.",
       "claims": [
         {
@@ -1040,7 +1040,7 @@
         "unknown": 8
       },
       "verificationLevel": "L4",
-      "verificationLabel": "Independent re-analysis",
+      "verificationLabel": "We re-analysed their deposited data",
       "verificationDetail": "Downloaded NeuroVault NIfTI maps, independently counted significant voxels and found MNI peaks. Full MVPA pipeline not re-run.",
       "claims": [
         {
@@ -2836,7 +2836,7 @@
         "unknown": 5
       },
       "verificationLevel": "L3",
-      "verificationLabel": "Re-executed scripts",
+      "verificationLabel": "We ran their deposited scripts",
       "verificationDetail": "Ran deposited figure-generation scripts with matplotlib patch. Vmax parameter sweep timed out (600s) — 3 simulation claims unverified.",
       "claims": [
         {
@@ -4355,7 +4355,7 @@
         "unattempted": 2
       },
       "verificationLevel": "L4",
-      "verificationLabel": "Independent re-analysis",
+      "verificationLabel": "We re-analysed their deposited data",
       "verificationDetail": "Downloaded OpenNeuro CSVs, fit logistic regression independently, confirmed MNI peak coordinates. Full fMRI preprocessing not re-run.",
       "claims": [
         {
@@ -6316,7 +6316,7 @@
         "unknown": 9
       },
       "verificationLevel": "L2",
-      "verificationLabel": "CSV comparison",
+      "verificationLabel": "We compared their deposited CSVs",
       "verificationDetail": "Read deposited CSVs from GitHub, confirmed firing-rate values and STA timings. NEURON simulation not re-run (6 hrs + 1.88 GB Dryad).",
       "claims": [
         {
@@ -7902,7 +7902,7 @@
         "verified": 3
       },
       "verificationLevel": "unverified",
-      "verificationLabel": "Compute-infeasible",
+      "verificationLabel": "We could not re-run it — specialist compute",
       "verificationDetail": "Per-subject fMRI MVPA pipeline requires specialist compute. Data on OpenNeuro but pipeline not re-run.",
       "claims": [
         {
@@ -9266,7 +9266,7 @@
         "partial": 1
       },
       "verificationLevel": "L1",
-      "verificationLabel": "Metadata check",
+      "verificationLabel": "We checked the deposit exists",
       "verificationDetail": "Parsed PDB 9D57 record from RCSB, confirmed structure metadata. Wet-lab experiments not computationally reproducible.",
       "claims": [
         {
@@ -10574,7 +10574,7 @@
         "verified": 3
       },
       "verificationLevel": "unverified",
-      "verificationLabel": "Training data proprietary",
+      "verificationLabel": "We could not re-run it — training data is proprietary",
       "verificationDetail": "Deep learning pipeline trained on proprietary microscopy data. Pre-trained model available but training set not redistributable.",
       "claims": [
         {
@@ -12104,7 +12104,7 @@
         "unattempted": 2
       },
       "verificationLevel": "L2",
-      "verificationLabel": "CSV comparison",
+      "verificationLabel": "We compared their deposited CSVs",
       "verificationDetail": "Downloaded Stan posterior CSVs from OSF (live, not from-notes). Computed TVA statistics from posterior samples. 8/8 PASS. Full Stan model not re-run (12 hrs).",
       "claims": [
         {
@@ -13533,7 +13533,7 @@
         "verified": 5
       },
       "verificationLevel": "L4",
-      "verificationLabel": "Independent re-analysis",
+      "verificationLabel": "We re-analysed their deposited data",
       "verificationDetail": "Downloaded G-Node Excel data, computed independent statistical tests. Direction confirmed for all claims; one magnitude mismatch (maximal firing).",
       "claims": [
         {

--- a/site/src/lib/status.ts
+++ b/site/src/lib/status.ts
@@ -1,26 +1,104 @@
-export const STATUS_COLOR: Record<string, string> = {
-  // Verified statuses (green family)
-  'verified': '#22c55e',
-  'verified:partial': '#86efac',
-  'verified:with-nuance': '#fbbf24',
-  'verified:direction-and-trend': '#86efac',
-  'verified:interpretive': '#22c55e',
-  // Failed (red)
-  'failed': '#ef4444',
-  'failed:mismatch': '#ef4444',
-  // Unverified with reason (gray/orange)
-  'unverified:no-data': '#9ca3af',
-  'unverified:no-code': '#9ca3af',
-  'unverified': '#9ca3af',
-  'unverified:code-error': '#f97316',
-  'unverified:compute-infeasible': '#f97316',
-  'unverified:partial': '#f97316',
-  // Unknown (lightest gray — role will override)
-  'unknown': '#d1d5db',
-  'N/A': '#d1d5db',
+// What a reproduction record says, and what it must not be mistaken for.
+//
+// A record here means one thing: somebody re-ran the authors' deposited code against their
+// deposited data and compared the number that came out to the number in the paper. It is a
+// fact about *our* run, not about whether the claim is true. The site said "✓ verified" in
+// green and meant the first while reading as the second, on 61 of 254 claims — and said
+// "Unverified" in grey on the 48 nobody had attempted, which reads as a failing grade for
+// work not yet begun.
+//
+// Two rules follow, and they are why this file looks the way it does.
+//
+// THE SUBJECT IS US. Every label names what we did: "re-ran: numbers match", "not re-run
+// yet", "couldn't re-run". None of them is an adjective describing the claim.
+//
+// GREEN DOES NOT MEAN TRUE. Green and red are the universal truth signal and we were spending
+// them on provenance. Reproduction now uses the tooling palette — slate and blue — and nothing
+// on this site is green for "correct". The paper's own argument keeps the role colours, which
+// is where a reader's judgement of the science belongs.
+
+/** The outcome of a re-run, as a fact about the run. */
+export type ReproOutcome = 'match' | 'partial' | 'differs' | 'blocked' | 'not-attempted' | 'none';
+
+/** Stored status values map onto five outcomes. The stored vocabulary is unchanged — renaming
+ *  it is a corpus-wide migration and belongs in its own change — so the translation lives
+ *  here, at the one place the site reads it. */
+export function outcomeOf(status: string | null | undefined): ReproOutcome {
+  const s = status ?? '';
+  // Two vocabularies are stored. build-data.js derives a short one onto the claim —
+  // verified / partial / blocked / unattempted / unknown — while individual reproduction
+  // records use the longer `verified:*` and `unverified:*` forms. Both are read here, which
+  // is the point of having one translation: getting this wrong silently hides every chip,
+  // as it did until the built page was checked rather than the source.
+  if (s === 'verified') return 'match';
+  if (s === 'partial') return 'partial';
+  if (s === 'blocked') return 'blocked';
+  if (s === 'unattempted') return 'not-attempted';
+  if (s === 'unknown' || s === '') return 'none';
+
+  if (s.startsWith('failed')) return 'differs';
+  if (s === 'verified:interpretive') return 'match';
+  if (s.startsWith('verified')) return 'partial';
+  if (s === 'unverified' || s === 'unverified:partial') return 'not-attempted';
+  if (s.startsWith('unverified')) return 'blocked';
+  return 'none';
+}
+
+/** What we did, in the first person. Never an adjective about the claim. */
+export const OUTCOME_LABEL: Record<ReproOutcome, string> = {
+  'match': 're-ran: numbers match',
+  'partial': 're-ran: partly matches',
+  'differs': 're-ran: differs',
+  'blocked': 'couldn’t re-run',
+  'not-attempted': 'not re-run yet',
+  'none': '',
 };
 
-// Role-based colors for claims that don't get code verification
+/** The short form, for a chip clipped to a card. Still first-person. */
+export const OUTCOME_SHORT: Record<ReproOutcome, string> = {
+  'match': 're-ran · matches',
+  'partial': 're-ran · partly',
+  'differs': 're-ran · differs',
+  'blocked': 'couldn’t re-run',
+  'not-attempted': 'not re-run',
+  'none': '',
+};
+
+// Slate and blue: tooling, not verdict. `differs` is the one outcome that earns a warm colour,
+// because a reproduction that disagrees with the paper is a finding rather than a status.
+export const OUTCOME_TAILWIND: Record<ReproOutcome, string> = {
+  'match': 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+  'partial': 'bg-slate-50 text-slate-600 dark:bg-slate-800/60 dark:text-slate-400',
+  'differs': 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  'blocked': 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  'not-attempted': 'bg-transparent text-gray-400 dark:text-gray-600',
+  'none': 'bg-transparent text-gray-400 dark:text-gray-600',
+};
+
+/** Graph node colours for the reproduction layer, when it is switched on. */
+export const OUTCOME_COLOR: Record<ReproOutcome, string> = {
+  'match': '#475569',        // slate-600
+  'partial': '#94a3b8',      // slate-400
+  'differs': '#d97706',      // amber-600 — a disagreement is worth seeing
+  'blocked': '#cbd5e1',      // slate-300
+  'not-attempted': '#e2e8f0',
+  'none': '#e2e8f0',
+};
+
+/** Why we could not re-run it, where the stored status says. */
+export const BLOCKED_REASON: Record<string, string> = {
+  'unverified:no-data': 'no data deposited',
+  'unverified:no-code': 'no code deposited',
+  'unverified:code-error': 'the deposited code errored',
+  'unverified:compute-infeasible': 'needs specialist compute',
+};
+
+// ── The paper's own argument ────────────────────────────────────────────────
+// These colour the tree by what a claim *does* in the paper. They are the default, and with
+// the reproduction layer switched off they are all a reader sees — which is the test that the
+// separation is real: turn the layer off and the tree shows what the paper argues, carrying
+// no verdicts of ours at all.
+
 export const ROLE_COLOR: Record<string, string> = {
   'hypothesis': '#60a5fa',
   'prediction': '#60a5fa',
@@ -29,59 +107,35 @@ export const ROLE_COLOR: Record<string, string> = {
   'interpretation': '#60a5fa',
   'scope': '#94a3b8',
   'methodological': '#94a3b8',
-};
-
-export const STATUS_LABEL: Record<string, string> = {
-  'verified': 'Verified',
-  'verified:partial': 'Partially verified',
-  'verified:with-nuance': 'Verified with nuance',
-  'verified:direction-and-trend': 'Direction confirmed',
-  'verified:interpretive': 'Verified by reasoning',
-  'failed': 'Failed',
-  'failed:mismatch': 'Result mismatch',
-  'unverified:no-data': 'No data',
-  'unverified:no-code': 'No code',
-  'unverified': 'Unverified',
-  'unverified:code-error': 'Code error',
-  'unverified:compute-infeasible': 'Compute-infeasible',
-  'unverified:partial': 'Partially assessed',
-  'unknown': 'Unknown',
-  'N/A': 'N/A',
-};
-
-export const STATUS_TAILWIND: Record<string, string> = {
-  'verified': 'bg-green-100 text-green-800',
-  'verified:partial': 'bg-green-50 text-green-700',
-  'verified:with-nuance': 'bg-amber-50 text-amber-800',
-  'verified:direction-and-trend': 'bg-green-50 text-green-700',
-  'verified:interpretive': 'bg-green-100 text-green-800',
-  'failed': 'bg-red-100 text-red-800',
-  'failed:mismatch': 'bg-red-100 text-red-800',
-  'unverified:no-data': 'bg-gray-100 text-gray-700',
-  'unverified:no-code': 'bg-gray-100 text-gray-700',
-  'unverified': 'bg-gray-100 text-gray-700',
-  'unverified:code-error': 'bg-orange-100 text-orange-800',
-  'unverified:compute-infeasible': 'bg-orange-100 text-orange-800',
-  'unknown': 'bg-gray-50 text-gray-500',
+  'empirical': '#64748b',
+  'control': '#64748b',
 };
 
 export const EPISTEMIC_TAILWIND: Record<string, string> = {
-  'strong': 'bg-blue-100 text-blue-800',
-  'moderate': 'bg-yellow-100 text-yellow-800',
-  'weak': 'bg-red-100 text-red-800',
-  'contested': 'bg-red-100 text-red-800',
-  'hypothesis': 'bg-blue-50 text-blue-700',
-  'unknown': 'bg-gray-100 text-gray-600',
+  'strong': 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  'moderate': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  'weak': 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+  'contested': 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+  'hypothesis': 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  'unknown': 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
 };
 
-export function nodeColor(status: string, role?: string | null): string {
-  // If status is known and specific, use it
-  if (status && status !== 'unknown' && STATUS_COLOR[status]) {
-    return STATUS_COLOR[status];
+/** A claim's colour in the graph.
+ *
+ *  `repro` is the layer switch. Off — the default — a node is coloured by its role, so the
+ *  tree shows the paper's argument and none of our verdicts. On, a node carries the outcome
+ *  of our re-run in the tooling palette.
+ */
+export function nodeColor(status: string, role?: string | null, repro = false): string {
+  if (repro) {
+    const o = outcomeOf(status);
+    if (o !== 'none') return OUTCOME_COLOR[o];
   }
-  // For unknown/unset status, use role-based color
-  if (role && ROLE_COLOR[role]) {
-    return ROLE_COLOR[role];
-  }
-  return STATUS_COLOR[status] ?? '#d1d5db';
+  if (role && ROLE_COLOR[role]) return ROLE_COLOR[role];
+  return '#cbd5e1';
 }
+
+// ── Retired ─────────────────────────────────────────────────────────────────
+// STATUS_COLOR, STATUS_LABEL and STATUS_TAILWIND keyed the green/red truth palette directly
+// off the stored status and are gone. Anything that needs a label goes through `outcomeOf`,
+// which is the only place the stored vocabulary is read.

--- a/site/src/pages/papers/[paper].astro
+++ b/site/src/pages/papers/[paper].astro
@@ -56,8 +56,10 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const url = (path: string) => `${base}${path}/`;
 
 // Simple: are ALL claims verified?
-const verifiedCount = paperData.claims.filter((c: any) => c.status.startsWith('verified')).length;
-const allVerified = verifiedCount === paperData.claimCount && paperData.claimCount > 0;
+// Counted, not graded. `reran` is how many of this paper's claims we re-ran and the numbers
+// matched; it is a fact about our effort, and there is no honest one-word summary of a
+// paper's reproduction state, so the paper-level badge is gone.
+const reran = paperData.claims.filter((c: any) => c.status.startsWith('verified')).length;
 
 const stageLabel: Record<string, string> = {
   published: '',
@@ -114,9 +116,7 @@ const tabs = [
     <div class="mb-8">
       <div class="flex items-start gap-4 mb-1">
         <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100 leading-snug flex-1 m-0">{paperData.title}</h1>
-        {allVerified && (
-          <span class="flex-shrink-0 all-verified-badge">✓ All claims verified</span>
-        )}
+        
       </div>
       <div class="text-sm text-gray-600 dark:text-gray-400 mb-4">
         {paperData.authors.join(', ')} · {(paperData as any).journal}
@@ -170,11 +170,13 @@ const tabs = [
       <p class="paper-summary paper-summary-fallback">{paperSummaryFallback}</p>
     )}
 
-    <!-- Claim count + verified count -->
+    <!-- Claim count, and how many of them we re-ran -->
     <div class="mb-6 flex items-center gap-3">
       <span class="text-sm text-gray-500 dark:text-gray-400">{paperData.claimCount} claims</span>
-      {verifiedCount > 0 && !allVerified && (
-        <span class="text-sm text-green-700 dark:text-green-400 font-medium">{verifiedCount} verified</span>
+      {reran > 0 && (
+        <span class="text-sm text-slate-600 dark:text-slate-400">
+          {reran} re-run from deposited code
+        </span>
       )}
     </div>
 
@@ -324,17 +326,6 @@ const tabs = [
     vertical-align: baseline;
   }
 
-  .all-verified-badge {
-    font-size: 0.72rem;
-    font-weight: 600;
-    color: var(--ok-fg);
-    background: var(--ok-bg);
-    border: 1px solid var(--ok-border);
-    padding: 3px 10px;
-    border-radius: 4px;
-    letter-spacing: 0.02em;
-    white-space: nowrap;
-  }
 
   /* Alphabetical claim index at the bottom of the Claims tab */
   .alpha-index-details > summary {

--- a/site/src/pages/papers/index.astro
+++ b/site/src/pages/papers/index.astro
@@ -19,17 +19,14 @@ const stageLabel: Record<string, string> = {
     <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-8">Papers</h1>
     <div class="space-y-3">
       {papers.map(p => {
-        const verifiedCount = p.claims.filter((c: any) => c.status.startsWith('verified')).length;
-        const allVerified = verifiedCount === p.claimCount && p.claimCount > 0;
+        const reran = p.claims.filter((c: any) => c.status.startsWith('verified')).length;
         const stage = stageLabel[(p as any).stage] || '';
         return (
           <a href={url(`/papers/${p.slug}`)} class="flex items-start gap-4 p-4 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-400 hover:shadow-sm transition-all no-underline group">
             <div class="flex-1 min-w-0">
               <div class="flex items-start justify-between gap-3 mb-1">
                 <h2 class="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-blue-700 leading-snug">{p.title}</h2>
-                {allVerified && (
-                  <span class="flex-shrink-0 text-xs font-semibold text-green-800 bg-green-50 border border-green-200 px-2 py-0.5 rounded whitespace-nowrap">✓ All verified</span>
-                )}
+                
               </div>
               <div class="text-xs text-gray-500 dark:text-gray-400 mb-2">
                 {p.authors.join(', ')} · {p.journal}
@@ -40,11 +37,13 @@ const stageLabel: Record<string, string> = {
                 <span>{p.claimCount} claims</span>
                 {(p as any).verificationLevel && (p as any).verificationLevel !== 'unknown' && (
                   <span class={`font-medium ${
+                    /* A ramp, not a grade. L1–L4 is how far we got re-running a paper, and
+                       green on the higher rungs made it a score. */
                     (p as any).verificationLevel === 'unverified' ? 'text-gray-400' :
-                    (p as any).verificationLevel === 'L1' ? 'text-blue-500' :
-                    (p as any).verificationLevel === 'L2' ? 'text-green-600' :
-                    (p as any).verificationLevel === 'L3' ? 'text-green-600' :
-                    (p as any).verificationLevel === 'L4' ? 'text-green-700' : 'text-gray-400'
+                    (p as any).verificationLevel === 'L1' ? 'text-slate-400' :
+                    (p as any).verificationLevel === 'L2' ? 'text-slate-500' :
+                    (p as any).verificationLevel === 'L3' ? 'text-slate-600 dark:text-slate-400' :
+                    (p as any).verificationLevel === 'L4' ? 'text-slate-700 dark:text-slate-300' : 'text-gray-400'
                   }`}>{(p as any).verificationLevel}: {(p as any).verificationLabel}</span>
                 )}
               </div>


### PR DESCRIPTION
Closes #27. Site-side only — stored status values are unchanged, as the issue specifies.

## The problem

A green ✓ on **61 of 254 claims** meant one thing — a script re-ran the authors' deposited data and the number matched — and read as another: *this claim is true*. The **48 claims nobody had attempted** said "Unverified" in grey, which reads as a failing grade for work not yet begun.

## 1 · The subject is us

| stored | was | now |
|---|---|---|
| `verified` | ✓ verified | re-ran: numbers match |
| `partial` | partially verified | re-ran: partly matches |
| `failed` | result mismatch | re-ran: differs |
| `blocked` | unverified | couldn't re-run — *reason* |
| `unattempted` | unverified | not re-run yet |

The drawer's longer explanations too. The one that mattered most — *"A verification script ran against the deposited data and reproduced this result"* — now ends: **"That is a fact about the re-run, not about whether the claim is true."**

**The paper-level badge is deleted.** `✓ All claims verified` was the most misleading string on the site, and there is no honest one-word summary of a paper's reproduction state.

## 2 · Green stops meaning true

Reproduction moved to slate. The L1–L4 ladder lost its green rungs, which had made it a score. `differs` keeps a warm colour — a re-run that disagrees with the paper is a finding — but lost the red and the ✗, since a disagreement can be our error as easily as theirs.

The paper's own `supports` edges stay green. That is the paper's argument, not our verdict, and it is what a reader should be judging.

## 3 · The mark is attached, not intrinsic

The green left-rule on a "verified" card is gone. The chip sits on the card's edge, carries what we did, and **is absent entirely when we did nothing** — an absence of effort on our part is not a property of the claim.

The graph's reproduction layer is **a switch, off by default**. With it off the tree shows what the paper argues and carries no verdicts of ours. That was the issue's own test of whether the separation is real: *if turning the layer off changes nothing visible, it was never real.*

## Also

`L4: Independent re-analysis` sounded like replication and meant *we ran our own analysis on their deposited data*. Now `We re-analysed their deposited data`, and the taxonomy comment says plainly that no rung on the ladder is replication — which is the same category error #31 is about.

## One bug worth recording

`outcomeOf` was written against the `verified:*` / `unverified:*` vocabulary in `status.ts`, but claims carry a shorter one — `verified` / `partial` / `blocked` / `unattempted`. Every chip silently rendered as nothing. Found by checking the built page rather than the source. Both vocabularies are read now, at the one place the stored status is translated.

## Verified

513 pages. Chips across the corpus: **74 match, 22 partial, 80 blocked**. Zero "All verified" badges. Tests pass, `pipeline state` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)