### PR TITLE
The pipeline pages stop narrating themselves

### DIFF
--- a/docs/method.md
+++ b/docs/method.md
@@ -168,22 +168,18 @@ reclassifies roles and types, adds missing claims, removes spurious ones, revise
 adjudicates single-source candidates. Nothing reaches disk until the table is approved. It is
 the intellectual gate — the claim graph should be right before it is made permanent.
 
-As it runs today the gate does not exist, and the shape of its absence has changed. It used to
-be a flag with three settings, which bundled two unrelated things: `external` sent the draft to
-another model, and `interactive` opened an editor before anything was written. Only the second
-was review, and it reviewed the wrong object — what a curator edited was a draft table, while
-the version that reached the corpus was whatever the write step then made of it, which nobody
-saw.
+As it runs today the gate does not exist. Two things stand in its place, and neither of them is
+a person reading the corpus.
 
-Both are now what they are. The model's pass is the `external-review` layer, declared like any
-other, versioned and hashed. A person's approval is an operation on a version that already
-exists: `scripts/pipeline.py approve <paper> <layer> --by NAME` records who read which version
-of what, and because the record names the version, re-running the layer does not carry the
-approval forward — it was granted to text that no longer exists. Nothing forces an approval and
-none has been granted, so the corpus is still unreviewed; the difference is that this is now a
-readable fact about the data rather than a consequence of which flag was passed. The step is
-documented in full because it is what the method requires, and its absence is the single
-largest gap between the method and the artefact. Step 5 is where the schema's role labels (`hypothesis`, `prediction`, `empirical`, `control`, `scope`, `methodological`, `synthesis`, `interpretation`, `literature-context`) are first assigned definitively, because role-assignment requires the analyst's judgment about what kind of work each claim is doing in the paper's argument.
+A model's pass over the draft is the `external-review` layer, declared like any other and
+versioned and hashed with the rest. A person's approval is a separate operation, performed on a
+version that already exists: `scripts/pipeline.py approve <paper> <layer> --by NAME` records who
+read which version of what. Because the record names the version, re-running the layer does not
+carry the approval forward — it was granted to text that no longer exists.
+
+Nothing forces an approval and none has been granted. The corpus is unreviewed, and the
+approval ledger says so for every cell in it. The step is documented in full because it is what
+the method requires, and its absence is the largest gap between the method and the artefact. Step 5 is where the schema's role labels (`hypothesis`, `prediction`, `empirical`, `control`, `scope`, `methodological`, `synthesis`, `interpretation`, `literature-context`) are first assigned definitively, because role-assignment requires the analyst's judgment about what kind of work each claim is doing in the paper's argument.
 
 ### Step 6: Dependency mapping
 

--- a/site/src/pages/pipeline/index.astro
+++ b/site/src/pages/pipeline/index.astro
@@ -8,7 +8,7 @@ import PipelineExplorer from '../../components/PipelineExplorer';
 import { corpusExplorer } from '../../lib/explorer';
 import {
   layers, groups, papers, cells, titleOf, fill_of, inState, byId,
-  corpusLayers, paperLayers, STATE_LABEL, allHistory, resolve, approvedCells, shortOf,
+  corpusLayers, paperLayers, STATE_LABEL, allHistory, approvedCells, shortOf,
 } from '../../lib/pipeline';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -19,10 +19,6 @@ const stale = inState('stale', 'blocked');
 const absent = inState('absent');
 const open = corpusLayers.filter(l => l.open);
 const recent = allHistory().filter(h => !h.backfilled).slice(0, 6);
-// Findings belong to the layer that produced them and carry the date it was added, so a
-// returning reader sees what is new rather than a page that has quietly changed.
-const found = layers.filter(l => l.found)
-  .sort((a, b) => (a.added ?? '').localeCompare(b.added ?? ''));
 
 // One tone per state, as classes rather than inline styles so both themes are declared.
 const TONE: Record<string, string> = {
@@ -46,31 +42,28 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
     <header class="mb-10 max-w-3xl">
       <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0 mb-3">Pipeline</h1>
       <p class="text-gray-600 dark:text-gray-400 m-0 leading-relaxed">
-        A layer is a question asked of a paper. It reads declared inputs, produces a version, and
-        every run is recorded with the content hash of what it read — so whether a result is still
-        current is asked of the files rather than of anyone's memory. This page is that graph across
-        all {papers.length} papers; each layer's own page asks it of one.
+        A layer is a question asked of a paper — what does it claim, which claims does its
+        abstract carry, what did re-running its code produce. Each answer is a version, and
+        each run records the content hash of everything it read, so an answer that has fallen
+        behind its inputs says so.
+      </p>
+      <p class="text-gray-600 dark:text-gray-400 mt-3 m-0 leading-relaxed">
+        {papers.length} papers, {paperLayers.length} layers each. {counts.current ?? 0} of the
+        {totalCells} answers are current. None has been read and approved by a person.
       </p>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 m-0">
-        How the whole thing works is in <a href={url('/pipeline/method')} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">the methodology</a>,
-        why it is shaped this way in <a href={`${base}/design/2026-09-11-layers-as-pipeline.html`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">the design note</a>,
-        and each layer explains itself on its own page.
-        Generated from <code>pipeline/layers.yaml</code> and <code>runs/&lt;paper&gt;/ledger.jsonl</code>.
-        Every cell is fetchable at <code>/data/&lt;paper&gt;/&lt;layer&gt;.json</code>.
+        <a href={url('/pipeline/method')} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">How a paper is taken apart</a>,
+        and <a href={`${base}/design/2026-09-11-layers-as-pipeline.html`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">why the pipeline is shaped this way</a>.
       </p>
     </header>
 
     <!-- ── the graph ─────────────────────────────────────────────── -->
     <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">The layers</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4 max-w-2xl">
-      Ordered left to right by dependency. <strong class="font-medium text-gray-600 dark:text-gray-300">Columns</strong>
-      lists them by depth, which is the quickest way to see the whole set;
-      <strong class="font-medium text-gray-600 dark:text-gray-300">graph</strong> draws the
-      dependencies themselves, so hovering a layer lights everything a change to it would
-      disturb — staleness travels along exactly those edges. Dashed borders are corpus-scope:
-      schema and vocabulary decisions that belong to no single paper and, when they change,
-      unsettle every cell beneath them. Clicking a layer opens it here rather than moving you
-      to another page.
+      Every layer rests on the ones to its left, and a change travels the other way: revise the
+      claim format and every tree beneath it is out of date. Dashed borders mark the decisions
+      that belong to no single paper — what a relation asserts, what counts as a claim — which
+      is why altering one unsettles the whole corpus at once.
     </p>
 
     <PipelineExplorer client:load data={explorer} base={base} height={470} />
@@ -80,9 +73,8 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
     <!-- ── the matrix ────────────────────────────────────────────── -->
     <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">Which papers have which layer</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl">
-      A jagged edge is the normal condition, not a defect. A blank means the layer has not been run
-      for that paper — not that it was run and found nothing. A column heading or a cell opens that
-      layer in the panel above, without losing your place in the grid.
+      A blank is a layer that has not been run for that paper, not a layer that ran and found
+      nothing. No two papers have been through the same set.
     </p>
 
     <div class="overflow-x-auto mb-4">
@@ -151,8 +143,7 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
         Approval is an operation on a version, not a layer of its own: a person reads what a
         layer produced and approves <em>that output</em>. The approval names the version it was
         granted to, so running the layer again does not carry it forward. Every cell above can
-        be current — its inputs unchanged since it ran — and unread by anyone. That is the
-        state of this corpus, and it is a count rather than a caveat.
+        be current — its inputs unchanged since it ran — and unread by anyone.
       </p>
     </section>
 
@@ -203,43 +194,23 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       </section>
     </div>
 
-    <!-- ── what each layer found ─────────────────────────────────── -->
-    <section class="mb-12">
-      <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">What each layer found</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl">
-        A finding belongs to the layer that produced it and carries the date that layer was added.
-        Every figure is filled from <code>corpus-facts.json</code> at build; an unknown one fails
-        the build rather than rendering as a placeholder nobody notices.
-      </p>
-      <div class="space-y-5">
-        {found.map(l => (
-          <section class="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
-            <p class="font-mono text-xs text-amber-700 dark:text-amber-400 m-0 mb-1">
-              <a href={url(`/pipeline/${l.id}`)} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">{l.id}</a>
-              {l.added ? ` · ${l.added}` : ''}
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed m-0 max-w-3xl"
-               set:html={resolve(l.found!).replace(/`([^`]+)`/g, '<code class="text-xs">$1</code>')}></p>
-          </section>
-        ))}
-      </div>
-    </section>
-
     <!-- ── what has run lately ───────────────────────────────────── -->
     {recent.length > 0 && (
       <section class="mb-12">
         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">Recently run</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-          From the ledger, excluding entries backfilled from artifacts that predate it.
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4 max-w-2xl">
+          The last answers the corpus produced, newest first. Each opens the cell it filled.
         </p>
         <ul class="list-none p-0 m-0 space-y-2.5">
           {recent.map(h => (
             <li class="text-sm border-l-2 border-gray-200 dark:border-gray-700 pl-3">
-              <span class="font-mono text-xs text-gray-500 dark:text-gray-400">
-                {h.ran?.slice(0, 10)} · {(h as any).paper} ·
-                <a href={url(`/pipeline/${(h as any).layer}`)} class="text-amber-700 dark:text-amber-400 no-underline hover:underline"> {(h as any).layer}</a>
-                {' '}v{h.v}
-              </span>
+              {/* The entry is a cell — one paper, one layer, one version — so it links to the
+                  cell rather than to the layer in general. What ran is what changed. */}
+              <a href={url(`/papers/${(h as any).paper}/${(h as any).layer}`)}
+                 class="font-mono text-xs text-gray-500 dark:text-gray-400 no-underline hover:text-amber-700 dark:hover:text-amber-400">
+                {h.ran?.slice(0, 10)} · <span class="text-gray-700 dark:text-gray-300">{shortOf((h as any).paper)}</span> ·
+                <span class="text-amber-700 dark:text-amber-400">{(h as any).layer}</span> v{h.v}
+              </a>
               {h.note && <span class="block text-gray-700 dark:text-gray-300 leading-snug">{h.note}</span>}
             </li>
           ))}
@@ -251,6 +222,10 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       {layers.length} layers · {Object.keys(groups).length} groups ·
       {' '}{absent.length} cells not yet run ·
       <a href={`${base}/data/index.json`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline"> the whole matrix as JSON</a>
+      <span class="block mt-1.5 text-xs">
+        Declared in <code>pipeline/layers.yaml</code>, recorded in <code>runs/&lt;paper&gt;/ledger.jsonl</code>,
+        each cell at <code>/data/&lt;paper&gt;/&lt;layer&gt;.json</code>.
+      </span>
     </footer>
 
   </div>

--- a/site/src/pages/pipeline/relation-vocab.astro
+++ b/site/src/pages/pipeline/relation-vocab.astro
@@ -77,25 +77,16 @@ const layer = byId['relation-vocab'];
 
     <div class="max-w-3xl space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-10">
       <p>
-        Every claim, relation and verdict in this corpus was produced by a language model and
-        checked by nobody. That has been stated on this site since the
-        <a href={`${base}/agents/`} class="text-amber-700 dark:text-amber-400 hover:underline">Agents</a>
-        page went up. This is the first layer that does something about it: a queue of the
-        judgements a script cannot make, with everything needed to make them.
+        <code>dissociates-with</code> carries {edgeN} edges &mdash; more than every other
+        opposing relation in the corpus combined &mdash; and every MIRA export tells eLife it
+        means opposition. Read the pairs below and most of them are not oppositions: they are
+        two findings catalogued side by side.
       </p>
       <p>
-        The first queue is one relation. <code>dissociates-with</code> is the corpus&rsquo;s
-        most-used oppositional relation &mdash; {edgeN} declared edges, more than every other
-        opposing relation combined &mdash; and every MIRA export tells eLife it means
-        opposition. Reading the pairs suggests most of them are not oppositions at all. But
-        that reading is an agent&rsquo;s, and unverified, which is the whole reason this page
-        exists rather than a commit quietly relabelling {edgeN} edges.
-      </p>
-      <p>
-        Items are grouped by proposed reading rather than by paper, because reviewing means
-        comparing like with like: a group of near-identical catalogue entries can be settled in
-        one pass, while the handful carrying real argumentative weight want reading one at a
-        time. Both claims appear in full, so the judgement can be made from this page.
+        That reading is an agent&rsquo;s and nobody has checked it, which is why {edgeN} edges
+        are listed here for a decision rather than relabelled. Near-identical pairs are grouped
+        so they can be settled together; the few carrying argumentative weight are worth
+        reading one at a time.
       </p>
     </div>
 
@@ -271,9 +262,8 @@ const layer = byId['relation-vocab'];
         the items are alike, and one at a time where they are not.
       </p>
       <p>
-        This page is static and cannot take the decision. It renders
-        <code>review/{topic.topic}.json</code>, which is where decisions live &mdash; the same
-        file, so the queue and this page cannot disagree.
+        A decision is recorded in <code>review/{topic.topic}.json</code> &mdash; the same file
+        the queue above is rendered from, so the two cannot drift apart.
       </p>
       <pre class="bg-gray-900 dark:bg-black text-gray-100 rounded-lg p-4 text-xs overflow-x-auto"><code>{`# set "decision" on an item: ${ORDER.join(' | ')}
 python3 scripts/apply_review.py ${topic.topic} --paper gadeke-2026-guilt-insula


### PR DESCRIPTION
An audit of the user-facing prose, and the rewrite it argued for.

## The fault

One disease with four faces, and it is concentrated exactly where you'd expect: **the
writing is strongest where its subject is the science, and collapses where its subject is
the site.**

Counted across representative pages before this change:

| Page | talks about itself | project history | defends an alternative | repo trivia |
|---|---:|---:|---:|---:|
| `/` (claims) | 0 | 0 | 1 | 0 |
| `/papers` | 0 | 0 | 0 | 1 |
| **`/pipeline`** | **4** | **3** | **8** | **10** |
| `/pipeline/relation-vocab` | 5 | 4 | 5 | 3 |

The home page is the best-written page on the site and needed nothing. That is the evidence
for the rule: **the subject of a sentence should be a paper, a claim or a finding — not a
page, a layer or a decision.**

## What went

**The page describing its own controls.** *"Clicking a layer opens it here rather than
moving you to another page."* *"A column heading or a cell opens that layer in the panel
above, without losing your place in the grid."* An interface that works does not narrate its
own affordances — and both of those were written into it that same morning.

**The site recounting its own development.** *"That has been stated on this site since the
Agents page went up."* *"This is the first layer that does something about it."* *"the whole
reason this page exists rather than a commit quietly relabelling 65 edges."* The reader was
not present for any of it.

**Repository internals in the opening paragraph.** `layers.yaml` and `ledger.jsonl` move to
the footer, where provenance belongs and nobody has to walk past it to reach the corpus.

## What each layer found — removed

It was the **third copy**. `found` already renders on each layer's own page and in its
drawer. Laid out as a dated list on the page above them it became a development log, stale
the moment it was written — and the section's own first line said *a finding belongs to the
layer that produced it*, which is precisely the argument for not repeating it here.

Nothing is lost. The findings stay one click away, on the layers that produced them.

## Recently run — now goes somewhere

This is the **real** changelog: read from the ledger rather than written by hand. It was
linking to the layer in general, when an entry is one paper, one layer, one version. It now
opens that cell, and names the paper the way the rest of the site does (`Kämmer`, not
`kammer-2026-foveal-feedback`).

## What stayed, and why

The 73 "rather than" constructions were **the audit's own false positive**. In
`docs/method.md` most separate two things a practitioner could genuinely confuse — method
examples from corpus members, atlas inspection from analysis re-execution. That is what a
methodology document is for. Only the passage recounting what a retired CLI flag used to do
was cut.

*"Reproduced is not replicated"* stays for the same reason: it draws a distinction about the
evidence, and a reader who misses it misreads the corpus. What went is the identical
construction deployed about the website, where nothing was at stake.

## After

`/pipeline` measures 0 / 0 / 2, and the two remaining are the footer's provenance line.
574 pages, zero broken links, the 6 new recently-run cell links all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)