### PR TITLE
Two counts on /pipeline were answering a different question from the one they looked like

### DIFF
--- a/site/src/lib/explorer.ts
+++ b/site/src/lib/explorer.ts
@@ -100,7 +100,8 @@ const cellView = (paper: string, layer: LayerDecl, base: string): CellView | nul
 const layerView = (l: LayerDecl, base: string, only: string | null): LayerView => {
   const scoped = l.scope === 'corpus' ? [] : (only ? [only] : papers);
   const views = scoped.map(p => cellView(p, l, base)).filter((c): c is CellView => c !== null);
-  const done = views.filter(c => c.state === 'current' || c.state === 'stale').length;
+  // Filled, on the same terms as fill_of: an answer exists. `absent` is the empty state.
+  const done = views.filter(c => c.state !== 'absent').length;
   return {
     id: l.id,
     title: l.title,

--- a/site/src/lib/pipeline.ts
+++ b/site/src/lib/pipeline.ts
@@ -166,11 +166,20 @@ export function inState(...states: CellState[]): Cell[] {
   return papers.flatMap(p => cells(p).filter(c => states.includes(c.state)));
 }
 
-/** How full a paper is: the jagged edge, as a fraction. */
+/** How full a paper is: the jagged edge, as a fraction.
+ *
+ *  Filled means the cell holds an answer, which is a fact about the corpus. Whether that
+ *  answer's inputs can still be checked is a fact about the ledger, and the two were being
+ *  conflated: counting only `current` meant a cell whose output exists but predates the
+ *  ledger read as not done. Gädeke reported 4 of 21 while holding 18 answers, and the number
+ *  moved when runs were re-recorded without a single claim changing.
+ *
+ *  `absent` is the only state that is genuinely empty. What is checkable is counted
+ *  separately, on /pipeline, where the distinction is the subject rather than a side effect. */
 export function fill_of(paper: string): { done: number; total: number } {
   const cs = cells(paper);
   return {
-    done: cs.filter(c => c.state === 'current' || c.state === 'n/a').length,
+    done: cs.filter(c => c.state !== 'absent').length,
     total: cs.length,
   };
 }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -103,7 +103,7 @@ const reproduced = (f.reproduction_status?.verified ?? 0);
         </div>
         <div class="border-l-2 border-gray-300 dark:border-gray-600 pl-4">
           <p class="text-gray-900 dark:text-gray-100 font-medium m-0 mb-1">
-            The corpus has a jagged edge, and it is meant to be visible.
+            The corpus has a jagged edge.
           </p>
           <p class="text-sm text-gray-700 dark:text-gray-300 m-0 leading-relaxed">
             Every paper goes through the same {cells(pipelinePapers[0]).length} layers, and no two

--- a/site/src/pages/pipeline/index.astro
+++ b/site/src/pages/pipeline/index.astro
@@ -8,7 +8,7 @@ import PipelineExplorer from '../../components/PipelineExplorer';
 import { corpusExplorer } from '../../lib/explorer';
 import {
   layers, groups, papers, cells, titleOf, fill_of, inState, byId,
-  corpusLayers, paperLayers, STATE_LABEL, allHistory, approvedCells, shortOf,
+  corpusLayers, paperLayers, STATE_LABEL, allHistory, shortOf,
 } from '../../lib/pipeline';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -30,7 +30,6 @@ const TONE: Record<string, string> = {
   open:    'bg-blue-200 dark:bg-blue-900',
   unrecorded: 'bg-gray-300 dark:bg-gray-600',
 };
-const approved = approvedCells();
 const totalCells = papers.reduce((n, p) => n + cells(p).length, 0);
 const counts: Record<string, number> = {};
 for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.state] ?? 0) + 1;
@@ -48,8 +47,8 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
         behind its inputs says so.
       </p>
       <p class="text-gray-600 dark:text-gray-400 mt-3 m-0 leading-relaxed">
-        {papers.length} papers, {paperLayers.length} layers each. {counts.current ?? 0} of the
-        {totalCells} answers are current. None has been read and approved by a person.
+        {papers.length} papers, {paperLayers.length} layers each. {(counts.current ?? 0) + (counts.unrecorded ?? 0)} of
+        the {totalCells} cells hold an answer. None of them has been read and approved by a person.
       </p>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 m-0">
         <a href={url('/pipeline/method')} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">How a paper is taken apart</a>,
@@ -135,64 +134,81 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
     </div>
 
     <!-- ── approval, which is not a state ────────────────────────── -->
-    <section class="mb-12 border-l-2 border-amber-400 dark:border-amber-600 pl-4">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 m-0 mb-1">
-        Approved by a person: <span class="font-mono">{approved.length} of {totalCells}</span>
+    <!-- ── the open questions ────────────────────────────────────
+         First, because they are the only thing on this page a reader can act on: three
+         decisions about what the vocabulary means, each with everything downstream of it
+         provisional until somebody rules. -->
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">
+        Undecided <span class="font-mono text-base text-gray-400 dark:text-gray-500">{open.length}</span>
       </h2>
-      <p class="text-sm text-gray-700 dark:text-gray-300 m-0 max-w-3xl leading-relaxed">
-        Approval is an operation on a version, not a layer of its own: a person reads what a
-        layer produced and approves <em>that output</em>. The approval names the version it was
-        granted to, so running the layer again does not carry it forward. Every cell above can
-        be current — its inputs unchanged since it ran — and unread by anyone.
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl">
+        Questions the corpus has not answered. Each is a decision about what the schema means,
+        and every claim tree built under one is provisional until it is taken.
       </p>
+      <div class="grid md:grid-cols-3 gap-4">
+        {open.map(l => (
+          <a href={url(`/pipeline/${l.id}`)}
+             class="block border border-gray-200 dark:border-gray-700 rounded-lg p-4 no-underline hover:border-amber-500 dark:hover:border-amber-500 transition-colors">
+            <span class="block text-[15px] font-medium text-gray-900 dark:text-gray-100 mb-1">{l.title}</span>
+            <span class="block text-sm text-gray-600 dark:text-gray-400 leading-snug mb-2"
+                  set:html={l.question.replace(/`([^`]+)`/g, '<code class="text-[12.5px]">$1</code>')}></span>
+            {l.issue && (
+              <span class="font-mono text-xs text-amber-700 dark:text-amber-400">#{l.issue}</span>
+            )}
+          </a>
+        ))}
+      </div>
     </section>
 
-    <!-- ── the two standing queries ──────────────────────────────── -->
-    <div class="grid md:grid-cols-2 gap-6 mb-12">
-      <section>
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          Out of date <span class="font-mono text-sm text-gray-400 dark:text-gray-500">{stale.length}</span>
-        </h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-          A cell whose declared inputs have changed since it ran, or which sits behind one.
-        </p>
-        {stale.length === 0 ? (
-          <p class="text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 rounded-lg p-4 m-0">
-            Nothing. Every recorded run still matches the files it read.
+    <!-- ── what the ledger can and cannot vouch for ──────────────────
+         "Out of date: 0" was true and misleading. Staleness is computed by comparing a run's
+         recorded input hashes against the files now; a cell with no recorded run has nothing
+         to compare, so it cannot be found stale however old it is. Reporting the zero without
+         the denominator let a reader take it for "everything here is current". -->
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">How much of this is checkable</h2>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl">
+        A cell goes stale when a file it read has changed since. That comparison needs a
+        recorded run, and most of this corpus predates the ledger.
+      </p>
+      <div class="grid sm:grid-cols-3 gap-4">
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <span class="block text-2xl font-semibold text-gray-900 dark:text-gray-100 tabular-nums">{counts.current ?? 0}</span>
+          <span class="block text-sm text-gray-600 dark:text-gray-400 leading-snug mt-1">
+            ran with their inputs recorded, and every one still matches the files it read
+          </span>
+        </div>
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <span class="block text-2xl font-semibold text-gray-900 dark:text-gray-100 tabular-nums">{counts.unrecorded ?? 0}</span>
+          <span class="block text-sm text-gray-600 dark:text-gray-400 leading-snug mt-1">
+            produced an output before the ledger existed. Whether they are current is not
+            known and cannot be worked out from what was kept
+          </span>
+        </div>
+        <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <span class="block text-2xl font-semibold text-gray-900 dark:text-gray-100 tabular-nums">{absent.length}</span>
+          <span class="block text-sm text-gray-600 dark:text-gray-400 leading-snug mt-1">
+            have never been run
+          </span>
+        </div>
+      </div>
+      {stale.length > 0 && (
+        <div class="mt-4 border-l-2 border-amber-400 dark:border-amber-600 pl-4">
+          <p class="text-sm text-gray-700 dark:text-gray-300 m-0 mb-2">
+            {stale.length} cell{stale.length === 1 ? ' has' : 's have'} fallen behind an input:
           </p>
-        ) : (
           <ul class="list-none p-0 m-0 space-y-1.5">
             {stale.map(c => (
               <li class="text-sm">
-                <span class="font-mono text-xs text-amber-700 dark:text-amber-400">{c.paper} · {c.layer.id}</span>
+                <a href={url(`/papers/${c.paper}/${c.layer.id}`)} class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">{shortOf(c.paper)} · {c.layer.id}</a>
                 {c.moved && <span class="block text-xs text-gray-500 dark:text-gray-400 font-mono">← {c.moved[0]}</span>}
               </li>
             ))}
           </ul>
-        )}
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          Undecided <span class="font-mono text-sm text-gray-400 dark:text-gray-500">{open.length}</span>
-        </h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-          Question layers with no answer yet. Everything downstream of one is provisional.
-        </p>
-        <ul class="list-none p-0 m-0 space-y-2">
-          {open.map(l => (
-            <li>
-              <a href={url(`/pipeline/${l.id}`)} class="text-sm text-amber-700 dark:text-amber-400 no-underline hover:underline font-medium">{l.title}</a>
-              <span class="block text-sm text-gray-600 dark:text-gray-400 leading-snug">{l.question}</span>
-              {l.issue && (
-                <a href={`https://github.com/zmainen/elife-claim-trees/issues/${l.issue}`}
-                   class="text-xs font-mono text-gray-500 dark:text-gray-400 no-underline hover:underline" target="_blank">#{l.issue}</a>
-              )}
-            </li>
-          ))}
-        </ul>
-      </section>
-    </div>
+        </div>
+      )}
+    </section>
 
     <!-- ── what has run lately ───────────────────────────────────── -->
     {recent.length > 0 && (
@@ -223,8 +239,14 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       {' '}{absent.length} cells not yet run ·
       <a href={`${base}/data/index.json`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline"> the whole matrix as JSON</a>
       <span class="block mt-1.5 text-xs">
-        Declared in <code>pipeline/layers.yaml</code>, recorded in <code>runs/&lt;paper&gt;/ledger.jsonl</code>,
-        each cell at <code>/data/&lt;paper&gt;/&lt;layer&gt;.json</code>.
+        {/* Named paths are worth printing only if a reader can open them; the per-cell URL
+            pattern is documented by the "cell as JSON" link on every cell instead. */}
+        Declared in
+        <a href="https://github.com/zmainen/elife-claim-trees/blob/main/pipeline/layers.yaml"
+           target="_blank" rel="noopener" class="text-amber-700 dark:text-amber-400 no-underline hover:underline"><code>layers.yaml</code></a>,
+        recorded in
+        <a href="https://github.com/zmainen/elife-claim-trees/tree/main/runs"
+           target="_blank" rel="noopener" class="text-amber-700 dark:text-amber-400 no-underline hover:underline"><code>runs/</code></a>.
       </span>
     </footer>
 


### PR DESCRIPTION
Follows #47. Started as prose cleanup, turned up a correctness bug.

## `fill_of` counted bookkeeping, not content

`fill_of` counted only cells in state `current`. A cell whose output exists but whose run
predates the ledger is `unrecorded` — and it was counted as **not done**.

**Gädeke reported 4 of 21 while holding 18 answers.**

The tell is that the number moved when nothing in the corpus did: re-recording export runs
on `main` flipped cells between `current` and `unrecorded`, and a paper's apparent
completeness changed by a factor of four without a claim being touched.

Filled now means the cell holds an answer; `absent` is the only empty state. Corrected
across the homepage, `/papers` and `/pipeline`, which now agree.

| paper | was | is |
|---|---:|---:|
| Gädeke | 4/21 | **18/21** |
| Kolb | 3/21 | 10/21 |
| Ejdrup | 3/21 | 9/21 |

## "Out of date: 0" — true, and misleading

A cell is found stale by comparing the input hashes its run recorded against the files now.
A cell with **no recorded run has nothing to compare**, so it cannot be found stale however
old it is — and 68 of the 93 filled cells have no recorded run.

`Out of date: 0` beside *"Nothing. Every recorded run still matches the files it read"*
invited the reading that everything is current. The word *recorded* was carrying the entire
caveat.

Replaced with three counts that say which is which:

- **25** ran with their inputs recorded, and every one still matches
- **68** produced an output before the ledger existed — freshness unknown and unknowable from what was kept
- **117** never run

## The approval section is gone

A block explaining that approval is an operation on a version, on a page where the count has
been zero since the ledger existed. That nobody has approved anything is worth one clause in
the opening paragraph, which it now has. It did not need a section defending the design of a
feature no one has used.

## Undecided promoted

It is the only thing on the page a reader can **act on** — three decisions about what the
schema means, each leaving everything downstream provisional — and it was a list in the
right-hand half of a two-column block below the fold. Now three cards, directly under the
matrix.

## Smaller

- `layers.yaml` and `runs/` in the footer are links. A named path a reader cannot open is
  decoration. The per-cell URL pattern goes — every cell already carries a "cell as JSON" link.
- *"The corpus has a jagged edge, and it is meant to be visible"* loses its second clause,
  the sibling of the line cut from `/pipeline` in #47.

574 pages, zero broken links, frame check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)