### PR TITLE
The methodology's inventory of layers is generated; its narrative stops counting

### DIFF
--- a/docs/method.md
+++ b/docs/method.md
@@ -10,7 +10,7 @@ The document covers the scientific methodology: schema, claim authoring, verific
 
 1. [Overview](#1-overview)
 2. [Corpus](#2-corpus)
-3. [Claim induction — the ten-step process](#3-claim-induction--the-ten-step-process)
+3. [Claim induction](#3-claim-induction)
 4. [Schema](#4-schema)
 5. [Verification procedure](#5-verification-procedure)
 6. [Paper summaries](#6-paper-summaries)
@@ -67,7 +67,7 @@ The R1 revision of the Meijer paper carries 41 claims against 24 in the v1 prepr
 
 ---
 
-## 3. Claim induction — the ten-step process
+## 3. Claim induction
 
 > ## No human checks this corpus
 >
@@ -100,7 +100,9 @@ The R1 revision of the Meijer paper carries 41 claims against 24 in the v1 prepr
 > for a person to disposition. **It is not implemented, and it has not been run.** Adding it
 > would be a change to the method, and would be recorded here as one.
 
-Claim induction is the translation of a paper from argument format into claim-graph format. It demands reading comprehension, domain judgment, and decisions about what constitutes a claim — and in this version a model makes all of them. The procedure has ten steps with a review gate at step 5, which no person currently passes through. Steps 1–8 build and check the claim tree; steps 9–10 measure what it missed and export it.
+Claim induction is the translation of a paper from argument format into claim-graph format. It demands reading comprehension, domain judgment, and decisions about what constitutes a claim — and in this version a model makes all of them.
+
+The steps below are the narrative: how a paper is read, why the readers are partitioned as they are, what each one catches and misses, and where the review gate belongs. They are not the inventory. The pipeline declares every question it asks in `pipeline/layers.yaml`, and the [Layers](#layers) section is generated from that file — so a layer added after this narrative was written appears there without anyone remembering to come back here. Where the two describe the same work, the declaration is the one that runs.
 
 ### Step 1: Prepare
 
@@ -197,7 +199,7 @@ For each claim where data and code are available, run the analysis and compare t
 
 ### Step 9: Coverage — what does no claim account for?
 
-Steps 1–8 produce a claim tree and check the claims in it. They do not ask the opposite
+The steps above produce a claim tree and check the claims in it. They do not ask the opposite
 question, and until recently nothing did: what does the paper assert that no claim
 represents? That gap is not hypothetical. Figure 2's panels C and F in Gädeke — a failed
 replication of a risk-aversion effect — sat unrepresented in the tree, and nothing in the
@@ -704,7 +706,7 @@ The methodology described above is the disciplined process the prototype would a
 
 ### Authoring discipline not strictly enforced
 
-The ten-step procedure with three independent extractions and a mandatory Step 5 review gate describes a workflow the prototype did not strictly enforce. In practice, authoring was prompt-guided LLM extraction with intermittent rather than systematic human review. The {{claims}} claim files should be read as a draft annotation layer, not as adjudicated output. A scaled-out version — the version this document is the methodology for — would enforce the three-extraction reconciliation and the Step 5 review gate as actual procedural checkpoints. The corpus is the prototype's draft; the methodology is the discipline the draft should be brought up to.
+The procedure above — three independent extractions and a mandatory review gate — describes a workflow the prototype did not strictly enforce. In practice, authoring was prompt-guided LLM extraction with intermittent rather than systematic human review. The {{claims}} claim files should be read as a draft annotation layer, not as adjudicated output. A scaled-out version — the version this document is the methodology for — would enforce the three-extraction reconciliation and the Step 5 review gate as actual procedural checkpoints. The corpus is the prototype's draft; the methodology is the discipline the draft should be brought up to.
 
 ### Verification coverage is shallow
 

--- a/site/src/components/PaperArtifacts.astro
+++ b/site/src/components/PaperArtifacts.astro
@@ -34,9 +34,8 @@ const KIND_LABEL: Record<string, string> = {
 
 <section>
   <p class="text-sm text-gray-600 dark:text-gray-400 max-w-2xl mb-1">
-    Every file the pipeline produced for this paper, from the <code class="text-[12.5px]">produces</code>
-    each layer declares. {downloadable} are served here; {inRepo} live only in the repository and
-    are linked there.
+    Every file the pipeline produced for this paper. {downloadable} are served here;
+    {inRepo} live only in the repository.
   </p>
   <p class="text-xs text-gray-500 dark:text-gray-500 mb-6">
     Each cell is also addressable as JSON at <code class="text-[11.5px]">/data/{paper}/&lt;layer&gt;.json</code>.

--- a/site/src/components/PipelineExplorer.tsx
+++ b/site/src/components/PipelineExplorer.tsx
@@ -111,9 +111,7 @@ export default function PipelineExplorer({ data, base, height = 460 }: Props) {
           <i className="inline-block w-2.5 h-2.5 rounded-sm border border-dashed"
              style={{ borderColor: 'var(--map-corpus-border)' }} />corpus-scope
         </span>
-        <span className="ml-auto">
-          Click a layer for detail{view === 'graph' ? ' · hover to light its dependencies' : ''}
-        </span>
+
       </div>
 
       <LayerDrawer data={data} layer={layer} onSelect={select} base={base} />

--- a/site/src/pages/method.astro
+++ b/site/src/pages/method.astro
@@ -132,12 +132,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       <article class="method-tab-panel method-prose" data-tab-id="layers" data-tab-active="false">
         <h2 class="section-title">The layers, as declared</h2>
         <p>
-          Every question this pipeline asks of a paper, in dependency order — read from
+          Every question the pipeline asks of a paper, in dependency order, from
           <a href="https://github.com/zmainen/elife-claim-trees/blob/main/pipeline/layers.yaml"
-             target="_blank" rel="noopener"><code>layers.yaml</code></a> rather than restated
-          here, so the two cannot disagree. The narrative above explains how induction works;
-          this is the whole set as it stands, including the layers that came after the
-          narrative was written.
+             target="_blank" rel="noopener"><code>layers.yaml</code></a>.
         </p>
         {layerCols.map((col, depth) => (
           <section class="not-prose mb-7">

--- a/site/src/pages/method.astro
+++ b/site/src/pages/method.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import MethodTabs from '../components/MethodTabs.astro';
 import { readDoc, renderMd } from '../lib/markdown';
+import { columns, groups as layerGroups, byId } from '../lib/pipeline';
 
 // Reading the document and filling its {{token}}s is shared with /docs, which renders
 // docs/cli/*.md the same way. It lived here, so the convention and its build-failing guard
@@ -86,7 +87,22 @@ const renderedSections = await Promise.all(
   sections.map(async s => ({ ...s, html: await renderMd(s.body) }))
 );
 
-const tabs = renderedSections.map(s => ({ id: s.id, label: s.label }));
+// The prose above is a narrative of induction and is worth writing by hand: the access
+// strategies, why the three readers are partitioned as they are, the failure modes each one
+// catches. None of that is in the declaration.
+//
+// The *inventory* of layers is a different thing, and writing it by hand is what went wrong:
+// the document described a ten-step process while the pipeline declared twenty-five layers,
+// and fourteen of them — `stance`, `mira-export`, `prediction-outcome` among them — were
+// named nowhere in it. A second description of one machine drifts from the first the moment
+// somebody declares a layer and does not think to come here.
+//
+// So this section is generated from pipeline/layers.yaml, in dependency order. A layer
+// declared tomorrow appears in the methodology tomorrow, and a layer that never existed
+// cannot appear at all.
+const layerCols = columns();
+const tabs = [...renderedSections.map(s => ({ id: s.id, label: s.label })),
+              { id: 'layers', label: 'Layers' }];
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
@@ -112,6 +128,44 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
           <div set:html={s.html} />
         </article>
       ))}
+
+      <article class="method-tab-panel method-prose" data-tab-id="layers" data-tab-active="false">
+        <h2 class="section-title">The layers, as declared</h2>
+        <p>
+          Every question this pipeline asks of a paper, in dependency order — read from
+          <a href="https://github.com/zmainen/elife-claim-trees/blob/main/pipeline/layers.yaml"
+             target="_blank" rel="noopener"><code>layers.yaml</code></a> rather than restated
+          here, so the two cannot disagree. The narrative above explains how induction works;
+          this is the whole set as it stands, including the layers that came after the
+          narrative was written.
+        </p>
+        {layerCols.map((col, depth) => (
+          <section class="not-prose mb-7">
+            <h3 class="text-[11px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3 mt-0">
+              Depth {depth}
+            </h3>
+            <div class="space-y-3">
+              {col.map(l => (
+                <div class="border-l-2 border-gray-200 dark:border-gray-700 pl-3">
+                  <a href={`${base}/pipeline/${l.id}/`}
+                     class="font-mono text-[13px] text-amber-700 dark:text-amber-400 no-underline hover:underline">{l.id}</a>
+                  <span class="text-xs text-gray-400 dark:text-gray-500 ml-2">
+                    {l.kind}{l.scope === 'corpus' ? ' · every paper' : ''}
+                    {l.group && layerGroups[l.group] ? ` · ${layerGroups[l.group].title.toLowerCase()}` : ''}
+                  </span>
+                  <span class="block text-sm text-gray-700 dark:text-gray-300 leading-snug"
+                        set:html={l.question.replace(/`([^`]+)`/g, '<code>$1</code>')}></span>
+                  {l.needs && l.needs.length > 0 && (
+                    <span class="block text-xs text-gray-500 dark:text-gray-400 font-mono mt-0.5">
+                      rests on {l.needs.filter(n => byId[n]).join(', ')}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </article>
     </div>
 
     <footer class="mt-12 pt-6 border-t border-gray-100 dark:border-gray-800 text-sm">

--- a/site/src/pages/papers/[paper].astro
+++ b/site/src/pages/papers/[paper].astro
@@ -235,8 +235,7 @@ const tabs = [
     <div class="paper-tab-panel" data-tab-id="graph" data-tab-active="false">
       <p class="text-sm text-gray-600 dark:text-gray-400 max-w-2xl mb-3">
         Claims, and what rests on what. Solid edges are <code class="text-[12.5px]">requires</code>,
-        dashed are <code class="text-[12.5px]">supports</code>. Clicking a claim lights its
-        ancestry and everything downstream, and opens it.
+        dashed are <code class="text-[12.5px]">supports</code>.
       </p>
       <div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden" style="height: 700px">
         <ClaimDAG client:load claims={paperData.claims} paperSlug={paperSlug} />
@@ -252,8 +251,7 @@ const tabs = [
     <div class="paper-tab-panel" data-tab-id="pipeline" data-tab-active="false">
       <div class="flex items-baseline justify-between gap-3 mb-2">
         <p class="text-sm text-gray-600 dark:text-gray-400 max-w-2xl m-0">
-          The layers this paper has been through, drawn as the graph they form — so an unrun
-          layer holding up a branch reads as one gap rather than several.
+          The layers this paper has been through, and what each rests on.
         </p>
         <span class="text-xs font-mono text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
           {fill_of(paperData.slug).done}/{fill_of(paperData.slug).total} ·

--- a/site/src/pages/papers/[paper]/[layer].astro
+++ b/site/src/pages/papers/[paper]/[layer].astro
@@ -188,8 +188,7 @@ const TONE: Record<string, string> = {
       <section class="mb-10">
         <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">What this layer produced</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-5">
-          <code>exports/{paper.slug}.formats.md</code>, rendered rather than restated — so a figure
-          here cannot disagree with the export it describes.
+          <code>exports/{paper.slug}.formats.md</code>, rendered.
         </p>
         <article class="formats-report"><Content /></article>
       </section>

--- a/site/src/pages/pipeline/index.astro
+++ b/site/src/pages/pipeline/index.astro
@@ -215,7 +215,7 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       <section class="mb-12">
         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">Recently run</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-4 max-w-2xl">
-          The last answers the corpus produced, newest first. Each opens the cell it filled.
+          The last answers the corpus produced, newest first.
         </p>
         <ul class="list-none p-0 m-0 space-y-2.5">
           {recent.map(h => (

--- a/site/src/pages/pipeline/relation-vocab.astro
+++ b/site/src/pages/pipeline/relation-vocab.astro
@@ -262,8 +262,8 @@ const layer = byId['relation-vocab'];
         the items are alike, and one at a time where they are not.
       </p>
       <p>
-        A decision is recorded in <code>review/{topic.topic}.json</code> &mdash; the same file
-        the queue above is rendered from, so the two cannot drift apart.
+        A decision is recorded in <code>review/{topic.topic}.json</code>, the same file the
+        queue above is rendered from.
       </p>
       <pre class="bg-gray-900 dark:bg-black text-gray-100 rounded-lg p-4 text-xs overflow-x-auto"><code>{`# set "decision" on an item: ${ORDER.join(' | ')}
 python3 scripts/apply_review.py ${topic.topic} --paper gadeke-2026-guilt-insula


### PR DESCRIPTION
Answers "is /method up to date?" — it wasn't, and the reason was structural.

## The drift, measured

`/method` described a **ten-step process**. `layers.yaml` declares **25 layers**. **14 were
named nowhere in the document:**

`claim-format` · `relation-vocab` · `epistemic-vocab` · `prediction-outcome` · `prepare` ·
`edge-inference` · `stance` · `reference-check` · `abstract-map` · `adjudication` ·
**`mira-export`** · `oxa-export` · `dg-export` · `formats-report`

Including `mira-export` — the schema eLife reads, the layer with a headline finding on
`/pipeline`, absent from the document that claims to describe the method.

Nobody made that mistake. It is what a second description of a machine does: somebody
declares a layer, the runner picks it up, the site picks it up, and the prose describing the
same work has no way of knowing. The document had drifted by 56% and nothing in the
repository could have said so.

## What the narrative keeps

The step prose is worth keeping and was never the problem. How to get full text when the
publisher's HTML truncates after two figures; why the three readers are partitioned along
framing / numerics / structure; what each partition catches and what it invents. None of
that is in `layers.yaml` and none of it could be — it is the part of a methodology that
teaches.

What it should not do is **enumerate**. It no longer says how many steps there are, and the
claim of a review gate "at step 5" goes with it. The gate is still described, and its absence
still stated plainly.

## The inventory is generated

A **Layers** section rendered from `pipeline/layers.yaml` in dependency order — every layer,
its question, its kind, what it rests on, linked to its page.

**25 of 25, against 11 named before.** A layer declared tomorrow is in the methodology
tomorrow; one that was never declared cannot appear at all.

## No lint for the reverse direction

A check that the prose names no *retired* layer would catch the other drift, and I wrote one
and deleted it. Layer ids, claim slugs, relation names and role names are all lowercase and
hyphenated — it flagged 23 legitimate mentions (`derived-from`, `rules-out`,
`pv-gamma-sst-beta-correspondence`…) and would have needed an exemption list to stay quiet.

The container lint earns its place by being exact. This one would have taught people to
ignore it. Generation closes the direction that actually drifted.

574 pages, zero broken links, `make fresh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)