### PR TITLE
A layer page shows its prompt, its output, and the views it declares

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,14 @@
     {
       "name": "site",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["--prefix", "site", "run", "dev"],
-      "port": 4321
+      "runtimeArgs": [
+        "--prefix",
+        "site",
+        "run",
+        "dev"
+      ],
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ fresh: data  ## Fail if regenerating changed anything that was committed
 	  git status --porcelain -- $(GENERATED); \
 	  echo ""; \
 	  echo "Run 'make data' and commit the result."; \
-	  echo "If corpus-facts.json flipped a cell to \\`stale\\` with export paths under"; \
-	  echo "\\`moved\\`, the cause is exports/ — run 'make mira-exports' first."; \
+	  echo 'If corpus-facts.json flipped a cell to `stale` with export paths under'; \
+	  echo '`moved`, the cause is exports/ — run "make mira-exports" first.'; \
 	  exit 1; \
 	fi
 	@echo "Generated data matches the corpus."

--- a/docs/cli/prompts.md
+++ b/docs/cli/prompts.md
@@ -20,9 +20,11 @@ been built with the old one.
 | `edge-inference.md` | [`edge-inference`](/elife-claim-trees/pipeline/edge-inference/) | The draft's claims, numbered |
 | `coverage-adjudicator.md` | [`adjudication`](/elife-claim-trees/pipeline/adjudication/) | Unresolved coverage spans against the claim tree |
 
-The [agents page](/elife-claim-trees/pipeline/induction/) renders each prompt's full text
-alongside what it produced for the worked example, generated from the committed prompt files —
-so what a reader sees there cannot differ from what ran.
+Each layer's own page renders the prompt it runs under, in full, read from the committed file
+at build — so what a reader sees on
+[`results-reader`](/elife-claim-trees/pipeline/results-reader/) is the prompt that produced the
+claims below it on the same page. The [agents page](/elife-claim-trees/pipeline/induction/)
+shows all seven side by side, for reading them against each other.
 
 ## Shared structure
 

--- a/pipeline/layers.yaml
+++ b/pipeline/layers.yaml
@@ -18,7 +18,15 @@
 #   reads       paths that are inputs but not other layers' outputs: scripts, prompts, schema.
 #               Hashed like any input, so changing a prompt makes every run that used it stale.
 #   produces    paths this writes. `{paper}` is substituted per paper.
-#   views       how a version of this layer can be looked at
+#   views       how a version of this layer can be looked at. `list` and `table` are rendered
+#               generically from whatever the layer produced; the rest name a view that lives
+#               somewhere specific, and the layer page says where. A view named here and built
+#               nowhere is reported as such rather than printed as a word.
+#   how         how it works, in prose: what it is given, what it returns, and what it gets
+#               wrong. `question` says why the layer exists; this says how it answers. Rendered
+#               on the layer page above what it found. `{{token}}` is filled as in `found`.
+#   doc         where the narrative documentation for this layer is, deep-linked to its
+#               section. The layer page links it; it does not restate it.
 #   command     what runs it. `{paper}` and `{doi}` substituted. Absent means no runner exists.
 #   by_from     a key in the first produced file holding who answered — the model, for a layer
 #               a model answers. The runner reads it into the ledger's `by`, because from
@@ -70,6 +78,17 @@ layers:
     scope: corpus
     title: Claim format
     question: What is a claim, and what may be said about one?
+    doc: /pipeline/vocabulary/
+    how: >
+      One file per claim: a YAML frontmatter block over a markdown body, carrying a uuid, a slug,
+      the claim sentence, a `claim-type` and a `role`, the concepts it touches, an `epistemic` mark,
+      and an `assertions` list naming the paper that asserts it and with what stance. Relations are
+      frontmatter keys whose values are other claims' slugs, so the graph lives in the same files as
+      the claims and there is no separate edge store to fall out of step with them.
+
+      Almost everything below reads or writes this, which is why a change here is never small. The
+      document is a declared input of `relation-vocab` and `claim-tree` both, so editing it marks
+      every tree in the corpus stale.
     reads: [docs/claim-format.md]
     views: [document]
 
@@ -78,8 +97,19 @@ layers:
     scope: corpus
     title: Relation semantics
     question: What does each relation assert, and which are oppositions?
+    doc: /pipeline/vocabulary/
+    how: >
+      `scripts/relations.py` holds the vocabulary once — which relations exist, what each asserts,
+      which pairs are oppositions — after four scripts each kept their own copy of the list and the
+      four disagreed. `check_relations.py` runs that vocabulary over the corpus and is the gate
+      `make check` enforces.
+
+      What is undecided is not the implementation but the semantics: whether `supports` and
+      `consistent-with` assert different things, and whether opposition is one relation or several.
+      Until issue #19 closes, every count and every export downstream is provisional in the precise
+      sense that it would change if the answer did.
     needs: [claim-format]
-    reads: [scripts/relations.py, scripts/check_relations.py, exports/claim-relations.ttl]
+    reads: [scripts/relations.py, scripts/check_relations.py, docs/schema-mapping/claim-relations.ttl]
     views: [table, comparison]
     issue: 19
     open: true                 # no decision yet; everything downstream is provisional
@@ -89,6 +119,14 @@ layers:
     scope: corpus
     title: Epistemic vocabulary
     question: Does `epistemic` record support strength, or restate the role?
+    how: >
+      `epistemic:` appears in every claim file and means two things at once. On some claims it
+      records how strongly the evidence supports the proposition. On others it restates the claim's
+      role — a hypothesis marked `weak` because hypotheses are hypotheses, not because anything
+      about the evidence was measured.
+
+      Nothing runs here. There is no script and no output, which is what an open question looks like
+      before anyone has built the machinery to evaluate it.
     needs: [claim-format]
     views: [table]
     issue: 20
@@ -104,6 +142,16 @@ layers:
     status: proposed
     title: Prediction outcomes
     question: Did the paper's predictions come out, and does the tree say so?
+    how: >
+      The rule is mechanical. For each `role: prediction` claim it looks at the edges pointing in
+      and out, and sorts the prediction by the shape of that wiring: a `tests` edge with a
+      `confirms` beside it, a `tests` edge alone, a conjunction of several. It reads the graph and
+      nothing else — not the paper, and not whether the prediction was in fact met.
+
+      That limit is the point of running it. Three wiring conventions are in use across the corpus
+      and they split by paper rather than by case, so the buckets measure how the trees were written
+      as much as what the papers found. Accepting the rule would mean accepting that reading, which
+      is why the declaration is `proposed` and not accepted.
     needs: [claim-format, relation-vocab]
     reads: [scripts/prediction_outcome.py]
     produces: [review/prediction-outcome.json]
@@ -133,6 +181,17 @@ layers:
     scope: paper
     title: Prepared paper
     question: What text did the readers actually read?
+    doc: /docs/layers/#prepare--the-paper-the-readers-read
+    how: >
+      Fetches the paper and cuts it into the slices the three readers each get. For an eLife DOI
+      that is JATS XML from the CDN, which gives labelled sections, typed figures and caption text;
+      for anything else it is pdfplumber with regex section detection. Which path was taken is
+      recorded in the output, because it constrains what the readers can possibly extract. The fetch
+      is cached, so every later layer on the same paper runs offline and free.
+
+      Check the slice sizes when a paper extracts badly. A short `results` almost always means
+      section detection failed, and then all three readers read the wrong text and every claim below
+      them is wrong for the same single reason.
     reads: [extract/elife_extract/prepare.py]
     produces: ["runs/{paper}/prepared.json"]
     views: [document]
@@ -144,6 +203,17 @@ layers:
     scope: paper
     title: Results reader
     question: What does the Results section assert?
+    doc: /docs/layers/#the-three-readers
+    how: >
+      Given the abstract and the results prose — and nothing else: no captions, no methods, no
+      figures — it returns candidate claims, each with a role, a claim type, the panel where the
+      prose names one, and the verbatim sentence it rests on.
+
+      The partition is what makes it worth running separately. It is the only reader positioned to
+      see the paper's argument as an argument, so it is the one asked for hypotheses, predictions
+      and synthesis rather than for numbers. It is also the reader most prone to flattening exactly
+      that: where a paper derives a prediction from a hypothesis and then tests it, the easy output
+      is one empirical claim, and the longest section of the prompt below exists to stop that.
     needs: [prepare]
     reads: [extract/prompts/results-reader.md]
     produces: ["runs/{paper}/results-reader.output.json"]
@@ -157,6 +227,15 @@ layers:
     scope: paper
     title: Caption reader
     question: What do the figure captions assert?
+    doc: /docs/layers/#the-three-readers
+    how: >
+      Given the figure and table captions, panel by panel, it returns the quantitative claims
+      anchored to the panel that shows them. It does not see the results prose, so it cannot lift a
+      number out of a sentence that summarises one, and it does not see the methods, so it cannot
+      invent how a measurement was made.
+
+      Panel assignment is where the three readers most often disagree, and it is the standing
+      failure the evaluation harness measures.
     needs: [prepare]
     reads: [extract/prompts/caption-reader.md]
     produces: ["runs/{paper}/caption-reader.output.json"]
@@ -170,6 +249,13 @@ layers:
     scope: paper
     title: Structure reader
     question: What is the paper's argument structure?
+    doc: /docs/layers/#the-three-readers
+    how: >
+      Given the methods, the supplements and the section structure, it returns what the paper frames
+      as its own conclusions, together with the methodological capabilities and the scope conditions
+      the other two readers have no text for. Scope claims — what a study does and does not cover —
+      appear almost nowhere else in a paper, so a pipeline without this reader does not under-report
+      them, it loses them.
     needs: [prepare]
     reads: [extract/prompts/structure-reader.md]
     produces: ["runs/{paper}/structure-reader.output.json"]
@@ -183,6 +269,17 @@ layers:
     scope: paper
     title: Reconciliation
     question: Which candidates survive, and which readers agreed?
+    doc: /docs/layers/#reconcile--which-candidates-survive
+    how: >
+      Reads the three readers' outputs from disk and aligns them into one draft table. Each
+      surviving claim carries which readers proposed it and the evidence each quoted, and a
+      confidence that is a fact about agreement rather than about the world: `high` where more than
+      one reader surfaced it, `contested` where they surfaced it differently, `single-source` where
+      one did.
+
+      This is the whole reason the readers run separately rather than as one pass over the paper.
+      Agreement between three partitions is evidence; one agent reading everything produces a longer
+      list and no way to tell which of it is load-bearing.
     needs: [results-reader, caption-reader, structure-reader]
     reads: [extract/prompts/reconciler.md]
     produces: ["runs/{paper}/reconciler.output.json"]
@@ -201,6 +298,16 @@ layers:
     scope: paper
     title: External review
     question: What structure did the three readers systematically miss?
+    doc: /docs/layers/#external-review--what-the-readers-systematically-miss
+    how: >
+      One Opus pass over the reconciled draft with the paper beside it, recovering what prose-level
+      extraction systematically under-covers: the `prediction` and `hypothesis` roles, and multi-
+      panel claims collapsed onto a single panel. Roughly two dollars and three minutes a paper, and
+      it moved role agreement on the Headley round-trip from about 65% to about 96%.
+
+      It is not review in this file's sense — it is a second model, not a person, and it changes the
+      artifact rather than approving a version of one. Running it is optional: `claim-tree` builds
+      on this output where it exists and on the reconciled draft where it does not.
     added: "2026-09-11"
     needs: [reconcile]
     reads: [extract/prompts/external-reviewer.md]
@@ -215,6 +322,18 @@ layers:
     scope: paper
     title: Edge inference
     question: Which claims depend on which?
+    doc: /docs/layers/#edge-inference--which-claims-depend-on-which
+    how: >
+      Given the draft's claims, numbered, it returns typed relations between them — the deductive
+      spine, `entails` from a hypothesis to its predictions and `tests` back from the empirical
+      result. Edges naming an unknown slug, or pointing at themselves, are dropped: an invented
+      target is worse than a missing edge.
+
+      `--dump-prompt` writes the exact request and exits, so that an analyst or a different model
+      answers the question this layer would have asked rather than a paraphrase written from memory,
+      and `--edges-json` feeds that answer back through the same validation. Edges are the part of a
+      tree most easily lost to one failed call — every other stage can succeed and leave a paper
+      with claims and no structure at all.
     needs: [reconcile, relation-vocab]
     reads: [extract/prompts/edge-inference.md]
     produces: ["runs/{paper}/edge-inference.output.json"]
@@ -229,6 +348,16 @@ layers:
     scope: paper
     title: Claim tree
     question: What does this paper assert, and how do its assertions depend on each other?
+    doc: /docs/layers/#write--the-claim-tree
+    how: >
+      Assigns each surviving claim a slug and a UUID, attaches the edges `edge-inference` produced,
+      and writes one markdown file per claim into `claims/<paper>/` with the paper's `index.md`
+      beside them. It calls no model and needs no credentials — the reasoning already happened
+      upstream — but it does need those edges. Run it without them and the claims are written with
+      no structure, and it says so.
+
+      It refuses to overwrite a non-empty paper directory. The claim files are edited afterwards by
+      hand and by later layers, and a silent overwrite would discard work no ledger records.
     added: "2026-03"
     found: >
       Across {{papers}} papers the corpus holds {{claims}} claims and {{relations}} typed relations, using {{relation_types_used}} of the {{relation_types_defined}} defined relation types. The commonest role is `{{largest_role}}` at {{largest_role_n}} claims.
@@ -242,6 +371,15 @@ layers:
     scope: paper
     title: Alternatives and stance
     question: What does this paper rule out, and what does it merely entertain?
+    how: >
+      Adds the claims a paper argues against. Each is an ordinary claim file — prefixed `alt-` —
+      whose `assertions` entry carries `stance: rejects` rather than `asserts`, so an alternative
+      the paper rules out is a node in the graph like any other and an eliminative edge has
+      something correct to point at.
+
+      Before these existed, a rejected alternative lived only as prose inside the claim that
+      dismissed it, and an edge that should have pointed at it pointed at whatever claim was
+      nearest.
     added: "2026-09-10"
     found: >
       A missing node does not only lose information, it misdirects the edges that would have pointed at it. Five eliminative relations were found aiming at claims their own paper asserts. {{dangling_rules_out}} eliminative edges still name prose that resolves to no claim.
@@ -268,6 +406,18 @@ layers:
     scope: paper
     title: Reference check
     question: Do the cited references resolve, and to what?
+    doc: /docs/layers/#verify-refs--the-reference-check
+    how: >
+      Two different operations under one name, and the difference is the whole of what this layer is
+      worth. Where a `role: literature-context` claim already carries a top-level `doi:`, the layer
+      confirms with CrossRef that it resolves to a real paper: that is the anti-hallucination check.
+      Where there is no DOI, it extracts hints from the claim text and slug, queries CrossRef, and
+      writes back the highest-scoring match above a threshold — a search, which can return a
+      confident match to the wrong paper.
+
+      The report is what the layer produces; the confirmed DOIs land in the claim files themselves.
+      Two earlier implementations both edited those files and disagreed about the result, and one of
+      them recorded a fuzzy title match as a confirmed DOI.
     added: "2026-09-11"
     needs: [claim-tree]
     reads: [extract/elife_extract/verify_refs.py]
@@ -280,6 +430,14 @@ layers:
     scope: paper
     title: Abstract ↔ claims
     question: Which claims does the abstract carry, and which does it drop?
+    how: >
+      Cuts the abstract into sentences and asks of each which claims carry it, and of each claim
+      whether any sentence of the abstract does. The output holds both directions, and the
+      interesting column is the empty one: claims the tree holds that the abstract drops, and
+      abstract sentences no claim accounts for.
+
+      An abstract is the paper's own summary of itself, so the difference between the two lists is
+      the difference between what a paper found and what it advertises.
     needs: [claim-tree]
     produces: ["site/src/data/abstract-mapping/{paper}.json"]
     views: [document, comparison]
@@ -298,6 +456,14 @@ layers:
     scope: paper
     title: Argument from graph
     question: Restated from the claim graph alone, what does this paper argue — and where does that part from its abstract?
+    how: >
+      Restates the paper's argument from the claim graph alone — no abstract, no prose — and then
+      holds that restatement against the abstract the authors wrote. Every sentence of the
+      restatement carries the claims and edges it was built from, so any of it can be followed back
+      to the nodes that produced it.
+
+      It is the closest thing in the pipeline to a test of whether the graph was worth building: if
+      the tree carries the argument, a restatement from it should be recognisable as the same paper.
     added: "2026-09-11"
     needs: [claim-tree, abstract-map]
     produces: ["site/src/data/synthesis-v3/{paper}.json"]
@@ -308,6 +474,16 @@ layers:
     scope: paper
     title: Verification
     question: Did anyone check, and what did they find?
+    how: >
+      Runs the paper's own deposited script under observation and records what it actually did —
+      every path it opened, every value it computed — rather than what its output said it did.
+      Nothing is taken from the script's own account of itself, because that is precisely what
+      failed: the first script audited had a claim recorded `verified` while the function named in
+      its record raised a shape-mismatch error, and a reproduction record naming a file the code
+      never opened.
+
+      This is not replication. It re-runs the authors' code on the authors' data, so it can catch a
+      record that does not match its own run and it cannot tell you whether the finding is true.
     added: "2026-09-06"
     found: >
       {{eligible_with_record}} of {{eligible_claims}} claims that a re-run could settle carry a reproduction record, and their outcomes are not uniform. Observing the runs from outside also showed that most records were reached by reading a deposit rather than by running the paper's own script.
@@ -324,6 +500,15 @@ layers:
     scope: paper
     title: Coverage
     question: What does the paper assert that no claim represents?
+    doc: /docs/layers/#coverage-and-mark
+    how: >
+      Takes its denominator from the paper rather than from the claim set. It builds the paper's own
+      inventories — every panel, every table, every reported statistic — cuts the whole text into
+      one-sentence spans, and asks of each span whether any claim accounts for it. Comparing two
+      claim sets cannot see what this sees: two trees can agree perfectly over a third of a paper.
+
+      It calls no model, so it is free and fast enough to run corpus-wide. What it cannot do is tell
+      a real gap from a string match that failed, which is what `adjudication` is for.
     added: "2026-09-10"
     found: >
       Gädeke first. The paper cut into spans and each adjudicated against the claim tree, which is how a tree is measured against its paper rather than against another tree. The mechanical match left 36 spans unaccounted for; 22 were the matcher being wrong and 14 were real.
@@ -337,6 +522,15 @@ layers:
     scope: paper
     title: Coverage adjudication
     question: Of the spans the matcher could not resolve, which are real gaps?
+    doc: /docs/layers/#coverage-and-mark
+    how: >
+      Reads the spans the mechanical match could not resolve and returns a verdict for each: the
+      span is covered by a claim after all, it states a result no claim carries, or it asserts
+      nothing at all. The verdicts are stored rather than recomputed — a verdict is a judgement
+      about meaning, and re-running it would quietly produce a different one.
+
+      On Gädeke the matcher left 36 spans unaccounted for. Adjudication found that 22 were the
+      matcher being wrong and 14 were real.
     needs: [coverage]
     reads: [extract/prompts/coverage-adjudicator.md]
     produces: ["mappings/{paper}.json"]
@@ -348,6 +542,14 @@ layers:
     scope: paper
     title: Marked paper
     question: Where, in the document itself, is each claim and each gap?
+    doc: /docs/layers/#coverage-and-mark
+    how: >
+      Writes the adjudicated verdicts into the document itself, as marks carrying each claim's UUID,
+      so a gap is something a reader sees in the paper rather than a number in a report. A span that
+      states no result says so; a span carrying a result no claim states is marked as a gap.
+
+      The marks are read straight back after writing and checked against the assignments they were
+      written from. A marked document that cannot reproduce them is not a record of anything.
     needs: [adjudication, claim-tree, prepare]
     produces: ["marked/{paper}.marked.md"]
     views: [document]
@@ -363,6 +565,14 @@ layers:
     scope: paper
     title: Replication
     question: Has an independent study found the same thing?
+    how: >
+      Nothing runs here, and the layer is declared so that the absence is a column rather than an
+      omission. The `replicates` relation is defined in the schema and used zero times: no claim in
+      this corpus has been checked against an independent study.
+
+      It is a different question from `verification`, answered by different evidence. Verification
+      re-runs the authors' own code on their own data and can tell you the record matches the run.
+      Only replication can tell you the finding holds.
     needs: [claim-tree]
     views: [table, comparison]
 
@@ -375,6 +585,15 @@ layers:
     scope: paper
     title: MIRA export
     question: What does the schema eLife reads carry, and what does it drop?
+    how: >
+      Writes two files and a gap report. `<paper>.mira.jsonld` is strict MIRA core, safe to hand to
+      any MIRA reader; `<paper>.mira-extended.jsonld` is the same graph plus a `haak:` namespace
+      carrying the structure MIRA has no vocabulary for; the gap report says what the strict file
+      dropped, and why.
+
+      The split is the design rather than a compromise in it. MIRA can express roughly half of what
+      a claim tree holds, and a single converted file either loses the other half quietly or emits
+      something a strict reader rejects.
     added: "2026-09-09"
     found: >
       {{mira_carried}} of {{mira_relations}} relations reach the export, with {{mira_our_violations}} validation violations attributable to the encoding. The gaps that remain are specific: {{mira_lost}} paper-level scope relations the schema has no node for, and {{mira_verification_records}} verification records for which no interchange format has a node type at all.
@@ -393,6 +612,13 @@ layers:
     scope: paper
     title: OXA export
     question: What does the open document architecture carry?
+    how: >
+      Reads the claim files and writes the paper as one OXA Article JSON with a Claim node per
+      claim. OXA is document-shaped rather than graph-shaped, so it keeps the text and the
+      sectioning of a paper well and carries relations as properties of the nodes they leave.
+
+      It is also the input to the Discourse Graphs export, so anything lost here is lost there too,
+      one conversion further along.
     needs: [claim-tree, stance]
     reads: [extract/scripts/migrate_to_oxa.py]
     produces: ["exports/{paper}.oxa.json"]
@@ -405,6 +631,14 @@ layers:
     scope: paper
     title: Discourse Graphs export
     question: What does the Q/C/E/S ontology carry?
+    how: >
+      Maps the OXA nodes onto the Discourse Graphs Q/C/E/S ontology: hypothesis, prediction,
+      synthesis and interpretation become `dg:Claim`; empirical and control become `dg:Evidence`;
+      literature-context becomes `dg:Source`. A relation becomes `dg:supports` or `dg:opposedBy`
+      where one of those fits, and carries its CiTO IRI as a typed annotation where neither does.
+
+      Four node types for nine roles: the mapping is lossy by construction, and `formats-report` is
+      where the amount is measured rather than asserted.
     needs: [oxa-export]
     reads: [extract/scripts/export_discourse_graphs.py]
     produces: ["exports/{paper}.dg.jsonld"]
@@ -417,6 +651,15 @@ layers:
     scope: paper
     title: Formats comparison
     question: Measured from the exports, what did each conversion cost?
+    how: >
+      Measures each conversion from the generated files rather than from the mapping tables. A
+      mapping table says what a converter intends; the export says what it did, and those two came
+      apart once already — the Discourse Graphs exporter looked for claims one level above where
+      they sit and wrote a file with a single node, in valid JSON-LD that nothing would have
+      flagged.
+
+      The markdown report is the artifact and the site renders it, so a figure on the page cannot
+      disagree with the export it describes.
     needs: [mira-export, oxa-export, dg-export]
     reads: [scripts/formats_report.py]
     produces:

--- a/site/src/components/LayerDefinition.astro
+++ b/site/src/components/LayerDefinition.astro
@@ -1,0 +1,88 @@
+---
+// What the layer runs under, on the layer's own page.
+//
+// For a layer a model answers, the prompt is not an input among others — it is the layer's
+// definition. Every rule the results-reader follows, every failure mode it is warned about,
+// the schema it must return: all of it is in a file the page named and did not show. The path
+// was rendered as a bare monospace string, so a reader who wanted to know what the layer
+// actually asks had to leave the site and find the file in the repository.
+//
+// The prompt is rendered here, whole, from the committed file. Nothing is restated — a
+// summary of a prompt is a second description to keep in step with the first, and this
+// repository has already lost that argument twice.
+//
+// A script gets its own account of itself instead: the module docstring, which is what these
+// scripts open with, and a link to the source. Rendering 600 lines of Python on a layer page
+// would bury the one paragraph a reader came for.
+import { renderMd } from '../lib/markdown';
+import { sources, type Source } from '../lib/layer-source';
+import type { LayerDecl } from '../lib/pipeline';
+
+interface Props { layer: LayerDecl; paper?: string }
+const { layer, paper } = Astro.props;
+
+const files: Source[] = sources(layer, paper);
+const rendered = await Promise.all(
+  files.map(async f => ({ ...f, html: f.text ? await renderMd(f.text) : null })));
+
+const LABEL: Record<string, string> = {
+  prompt: 'the prompt it runs under',
+  code: 'the script that runs it',
+  prose: 'the document it is defined by',
+  data: 'a declared input',
+};
+---
+
+{rendered.length > 0 && (
+  <section class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">How it is defined</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl leading-relaxed">
+      {rendered.some(f => f.kind === 'prompt')
+        ? <>A model answers this layer, so the prompt is the layer. It is reproduced below from the
+           committed file, and it is a declared input — editing it makes every run that used it
+           stale.</>
+        : <>What this layer reads besides its dependencies. Each is a declared input: its content
+           is hashed into every run, so editing one makes those runs stale.</>}
+    </p>
+
+    {rendered.map(f => (
+      <div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden mb-4">
+        <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/40 border-b border-gray-200 dark:border-gray-700">
+          <a href={f.href} target="_blank" rel="noopener"
+             class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">{f.path}</a>
+          <span class="text-xs text-gray-500 dark:text-gray-400">{LABEL[f.kind]}</span>
+          <span class="text-xs font-mono text-gray-400 dark:text-gray-500 ml-auto">
+            {f.exists ? `${f.lines} lines` : 'not in the repository'}
+          </span>
+        </div>
+
+        {!f.exists && (
+          <p class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 m-0 leading-relaxed">
+            The declaration names this path and the repository does not have it. An input that
+            does not exist hashes to nothing, so it cannot make a run stale — the layer is
+            declared to depend on something it is not in fact tracking.
+          </p>
+        )}
+
+        {f.summary && (
+          <div class="px-4 py-3">
+            <p class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 m-0 mb-1.5">
+              What it says it does
+            </p>
+            <pre class="m-0 text-[13px] leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-sans">{f.summary}</pre>
+          </div>
+        )}
+
+        {f.html && (
+          <details class="group">
+            <summary class="cursor-pointer list-none px-4 py-2.5 text-sm text-amber-700 dark:text-amber-400 hover:bg-gray-50 dark:hover:bg-gray-800/40">
+              <span class="group-open:hidden">Read all {f.lines} lines of it →</span>
+              <span class="hidden group-open:inline">Collapse</span>
+            </summary>
+            <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 method-prose" set:html={f.html} />
+          </details>
+        )}
+      </div>
+    ))}
+  </section>
+)}

--- a/site/src/components/LayerHeader.astro
+++ b/site/src/components/LayerHeader.astro
@@ -24,6 +24,14 @@ const KIND_NOTE: Record<string, string> = {
   question: 'A decision about meaning, and then the propagation of it through everything downstream.',
 };
 const code = (s: string) => s.replace(/`([^`]+)`/g, '<code class="text-[13px]">$1</code>');
+// `how` is a paragraph or three of prose in the declaration, written as a YAML folded scalar.
+// Folding turns each wrapped line into a space and each blank line into a single newline, so a
+// newline in the parsed value is exactly a paragraph break — which is why this splits on `\n`
+// and not on a blank line. Backticks become code, the same convention as everywhere else.
+// Nothing heavier is wanted: a markdown pipeline over a three-paragraph field is a dependency
+// bought to avoid writing one `split`.
+const paras = (s: string) =>
+  s.trim().split(/\n+/).map(p => `<p class="mb-3 last:mb-0">${code(p.trim())}</p>`).join('');
 ---
 
 <nav class="text-sm text-gray-500 dark:text-gray-400 mb-6">
@@ -57,6 +65,21 @@ const code = (s: string) => s.replace(/`([^`]+)`/g, '<code class="text-[13px]">$
     </p>
   )}
 </header>
+
+{(layer.how || layer.doc) && (
+  <section class="mb-9 max-w-2xl">
+    <h2 class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 m-0 mb-2">How it works</h2>
+    {layer.how && (
+      <div class="text-[15px] text-gray-700 dark:text-gray-300 leading-relaxed"
+           set:html={paras(resolve(layer.how))}></div>
+    )}
+    {layer.doc && (
+      <p class="text-sm m-0 mt-3">
+        <a href={`${base}${layer.doc}`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">How to run it, in the reference</a>
+      </p>
+    )}
+  </section>
+)}
 
 {layer.found && (
   <section class="mb-10 border-l-2 border-emerald-500 dark:border-emerald-600 pl-4">

--- a/site/src/components/LayerOutput.astro
+++ b/site/src/components/LayerOutput.astro
@@ -1,0 +1,124 @@
+---
+// What a layer produced, read from the file it produced, in the views the layer declares.
+//
+// The same block on a layer page (one paper, as the worked example) and on a cell page (this
+// paper's own run), because they are the same question at two altitudes and there is no reason
+// for two renderings of it to drift apart.
+//
+// Before this, `produces: runs/{paper}/results-reader.output.json` reached the page with its
+// placeholder unsubstituted and no link — the site named the file and could neither resolve it
+// nor open it — and `views: [list, table]` was two words beside it, implemented nowhere.
+//
+// A view is rendered because the declaration asks for it, not because the file would allow it.
+// So `prepare`, which declares `document`, shows the text the readers were given rather than a
+// table of the caption records that happen to sit in the same file; and a layer whose
+// declaration names a view nothing here draws says so on the same page, under Views.
+import { renderMd } from '../lib/markdown';
+import { output, size } from '../lib/layer-source';
+import { artifact } from '../lib/artifacts';
+import LayerRecords from './LayerRecords.astro';
+import type { LayerDecl } from '../lib/pipeline';
+
+interface Props {
+  layer: LayerDecl;
+  paper: string;
+  /** The layer's produced paths, already resolved for this paper. */
+  produces: string[];
+  heading?: string;
+  /** Text between the heading and the output. The layer page says which paper this is. */
+  note?: string;
+  limit?: number;
+}
+const { layer, paper, produces, heading = 'What it produced', note, limit } = Astro.props;
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const views = layer.views ?? [];
+const { path, records, document, sections } = output(produces);
+const art = path ? artifact(path, base) : null;
+const bytes = path ? size(path) : null;
+
+const asRecords = records?.records.length && views.some(v => v === 'list' || v === 'table');
+const asDocument = views.includes('document');
+const html = asDocument && document ? await renderMd(document.text) : null;
+const prose = asDocument ? (sections ?? []) : [];
+
+// The scalars beside the records: which model answered, which paper, what it counted. Worth a
+// line, because "answered by deepseek/deepseek-chat" is the provenance of everything below it.
+//
+// Only the short ones. `prepare` keeps the whole abstract and the whole results section in
+// string fields of the same file, and `verification` keeps the tail of the run's stdout, so a
+// line meant to carry six labels carried thirty thousand characters of paper. The long fields
+// are the document view; this is the caption above it.
+const META_MAX = 120;
+const meta = Object.entries(records?.meta ?? {})
+  .filter(([k, v]) => v !== null && v !== '' && k !== 'paper' && k !== 'paper_slug'
+                      && !(typeof v === 'string' && v.length > META_MAX));
+const kb = (n: number) => n < 1024 ? `${n} B` : `${Math.round(n / 1024)} KB`;
+const chars = (n: number) => `${(n / 1000).toFixed(1)}k characters`;
+---
+
+{path && (
+  <section class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">
+      {heading}
+      {asRecords && <span class="font-mono text-sm text-gray-400 dark:text-gray-500 ml-2">
+        {`${records!.records.length} ${records!.key ?? 'records'}`}
+      </span>}
+    </h2>
+
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-2xl leading-relaxed">
+      {note ? <>{note} </> : null}
+      Read from <a href={art!.href} target={art!.downloadable ? undefined : '_blank'}
+                   rel={art!.downloadable ? undefined : 'noopener'}
+                   class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">{path}</a>
+      {bytes ? <span class="text-gray-400 dark:text-gray-600">{` · ${kb(bytes)}`}</span> : null}
+      {art!.downloadable ? null : <span class="text-gray-400 dark:text-gray-600"> · in the repository</span>}.
+      {meta.length > 0 && (
+        <span class="block mt-1 font-mono text-xs">
+          {meta.map(([k, v]) => <span class="mr-3"><span class="text-gray-400 dark:text-gray-600">{`${k} `}</span>{String(v)}</span>)}
+        </span>
+      )}
+    </p>
+
+    {asRecords && (
+      <LayerRecords data={records!} views={views} limit={limit} id={`${paper}-${layer.id}`} />
+    )}
+
+    {html && (
+      <details class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <summary class="cursor-pointer list-none px-4 py-2.5 text-sm text-amber-700 dark:text-amber-400 hover:bg-gray-50 dark:hover:bg-gray-800/40">
+          Read the document →
+        </summary>
+        <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 method-prose" set:html={html} />
+        {document!.truncated && (
+          <p class="px-4 pb-4 text-xs text-gray-500 dark:text-gray-400 m-0">
+            Truncated here. The file has the rest.
+          </p>
+        )}
+      </details>
+    )}
+
+    {prose.length > 0 && (
+      <div class="space-y-2">
+        {prose.map(s => (
+          <details class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+            <summary class="cursor-pointer list-none px-4 py-2.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/40">
+              <span class="font-mono text-xs text-gray-700 dark:text-gray-300">{s.key}</span>
+              <span class="text-xs text-gray-400 dark:text-gray-600">{` · ${chars(s.chars)}`}</span>
+            </summary>
+            <pre class="m-0 px-4 py-3 border-t border-gray-100 dark:border-gray-800 text-[13px] leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-sans max-h-[32rem] overflow-y-auto">{s.text}</pre>
+          </details>
+        ))}
+      </div>
+    )}
+
+    {!asRecords && !html && prose.length === 0 && (
+      <p class="text-sm text-gray-500 dark:text-gray-400 m-0">
+        {views.length > 0
+          ? <>Nothing on this page renders {views.join(' or ')} for this file yet — the link above
+             is the artifact itself.</>
+          : <>The declaration names no view for this layer, so the artifact is offered as it is.</>}
+      </p>
+    )}
+  </section>
+)}

--- a/site/src/components/LayerRecords.astro
+++ b/site/src/components/LayerRecords.astro
@@ -1,0 +1,145 @@
+---
+// A layer's output, in the views the layer declares.
+//
+// `views: [list, table]` was an inert word on the page. The declaration said a version of this
+// layer can be looked at as a list or as a table, and the site rendered the two names as
+// prose and offered neither. A declared capability nothing implements is worse than an
+// undeclared one: it reads as a feature to anyone who has not tried to use it.
+//
+// Both are real here, over the same records, read from the artifact the layer produced. The
+// shape is not configured per layer — the fields are whatever the file has, in the order it
+// has them, so a reader's claims, an adjudication's spans and a verification's results all
+// render without this component knowing what any of them are.
+import type { Records } from '../lib/layer-source';
+
+interface Props {
+  data: Records;
+  views?: string[];
+  /** A ceiling on the list view, which is the long one. The table stays whole. */
+  limit?: number;
+  id?: string;
+}
+const { data, views = ['list', 'table'], limit = 60, id = 'out' } = Astro.props;
+
+// The field carrying the record's own text — what a list view is a list of. Named fields
+// first, because the corpus has names for them; otherwise the widest string field, which is
+// the same judgement made from the data when the name is one this file has not met.
+const NAMED = ['claim', 'text', 'sentence', 'prediction', 'title', 'question', 'from'];
+const width = (f: string) => {
+  const vs = data.records.map(r => r[f]).filter(v => typeof v === 'string') as string[];
+  return vs.length ? vs.reduce((a, b) => a + b.length, 0) / vs.length : 0;
+};
+const primary = NAMED.find(f => data.fields.includes(f) && width(f) > 0)
+  ?? [...data.fields].sort((a, b) => width(b) - width(a)).find(f => width(f) > 20);
+
+// Long strings beside the primary are the quotes: the evidence, the reason, the note. Shown
+// as quotations rather than as chips, because that is what they are.
+const quotes = data.fields.filter(f => f !== primary && width(f) > 60);
+const chips = data.fields.filter(f => f !== primary && !quotes.includes(f));
+
+// A list needs a column of text to be a list of. `edge-inference` produces source, target and
+// a relation type and nothing else, so it declares `table` and gets one; asking for a list
+// there would render ninety-five empty bullets.
+const show = views.filter(v => (v === 'list' && primary) || v === 'table');
+const panes = show.length ? show : ['table'];
+const cut = (v: unknown, n: number) => {
+  const s = v === null || v === undefined ? '' : String(v);
+  return s.length > n ? s.slice(0, n) + '…' : s;
+};
+const listed = data.records.slice(0, limit);
+
+// Column widths follow the field's own content: the record's text and its quotes get room,
+// a role or a confidence gets none it does not need. Without this every column took an equal
+// share and the claim — the one column anyone reads — wrapped to seven lines beside six
+// columns of one word.
+const colWidth = (f: string) =>
+  f === primary ? 'min-w-[16rem]' : quotes.includes(f) ? 'min-w-[13rem]' : 'min-w-[6rem]';
+---
+
+<div data-records id={id}>
+  {panes.length > 1 && (
+    <div class="flex gap-1 mb-4" role="group" aria-label="View">
+      {panes.map((v, i) => (
+        <button type="button" data-view={v} aria-pressed={i === 0}
+                class="px-2.5 py-1 text-xs font-mono rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-transparent text-gray-500 dark:text-gray-400 cursor-pointer aria-pressed:border-amber-500 aria-pressed:text-amber-700 dark:aria-pressed:text-amber-400">{v}</button>
+      ))}
+    </div>
+  )}
+
+  {panes.includes('list') && (
+    <div data-pane="list" hidden={panes[0] !== 'list'}>
+      <ol class="list-none p-0 m-0 space-y-4">
+        {listed.map(r => (
+          <li class="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
+            {primary && (
+              <p class="text-[15px] text-gray-800 dark:text-gray-200 m-0 leading-snug">{String(r[primary] ?? '')}</p>
+            )}
+            <p class="font-mono text-[11px] text-gray-500 dark:text-gray-400 m-0 mt-1">
+              {chips.map(f => r[f] === null || r[f] === undefined || r[f] === ''
+                ? null
+                : <span class="mr-3"><span class="text-gray-400 dark:text-gray-600">{`${f} `}</span>{cut(r[f], 60)}</span>)}
+            </p>
+            {quotes.map(f => r[f] ? (
+              <p class="text-xs text-gray-600 dark:text-gray-400 m-0 mt-1.5 italic leading-snug">
+                <span class="not-italic font-mono text-[10px] text-gray-400 dark:text-gray-600 mr-1.5">{f}</span>
+                {`“${cut(r[f], 320)}”`}
+              </p>
+            ) : null)}
+          </li>
+        ))}
+      </ol>
+      {data.records.length > listed.length && (
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-4 m-0">
+          {listed.length} of {data.records.length} shown. The table has all of them, and so does
+          the file.
+        </p>
+      )}
+    </div>
+  )}
+
+  {panes.includes('table') && (
+    <div data-pane="table" hidden={panes[0] !== 'table'} class="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+      <table class="w-full text-sm border-collapse">
+        <thead>
+          <tr class="text-left text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 border-b border-gray-200 dark:border-gray-700">
+            <th class="py-2 px-3 font-medium tabular-nums">#</th>
+            {data.fields.map(f => <th class={`py-2 px-3 font-medium whitespace-nowrap ${colWidth(f)}`}>{f}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {data.records.map((r, i) => (
+            <tr class="border-b border-gray-100 dark:border-gray-800 last:border-0 align-top">
+              <td class="py-2 px-3 font-mono text-xs text-gray-400 dark:text-gray-600 tabular-nums">{i + 1}</td>
+              {data.fields.map(f => (
+                <td class={`py-2 px-3 text-xs text-gray-700 dark:text-gray-300 max-w-[26rem] ${colWidth(f)}`}>
+                  {r[f] === null || r[f] === undefined
+                    ? <span class="text-gray-300 dark:text-gray-700">—</span>
+                    : typeof r[f] === 'object'
+                      ? <code class="text-[11px]">{cut(JSON.stringify(r[f]), 120)}</code>
+                      : cut(r[f], 200)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )}
+</div>
+
+<script>
+  // One listener for every record block on the page. The panes are rendered server-side and
+  // toggled with `hidden`, so the views work with no JavaScript beyond this switch — and the
+  // table is in the HTML whether or not anyone presses the button.
+  for (const block of document.querySelectorAll<HTMLElement>('[data-records]')) {
+    block.addEventListener('click', e => {
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('button[data-view]');
+      if (!btn) return;
+      const want = btn.dataset.view;
+      for (const b of block.querySelectorAll<HTMLButtonElement>('button[data-view]'))
+        b.setAttribute('aria-pressed', String(b.dataset.view === want));
+      for (const p of block.querySelectorAll<HTMLElement>('[data-pane]'))
+        p.hidden = p.dataset.pane !== want;
+    });
+  }
+</script>

--- a/site/src/components/LayerState.astro
+++ b/site/src/components/LayerState.astro
@@ -4,18 +4,64 @@
 // The same block on every layer page, bespoke or generic: which papers have been through this
 // layer, at what version, and — for those that have not — the command that would fill the
 // cell, taken from the declaration so the page and the runner cannot diverge.
-import { papers, cell, titleOf, STATE_LABEL, type LayerDecl } from '../lib/pipeline';
+//
+// Every path it names is now an address. `reads` and `produces` were printed as monospace
+// strings joined by a middle dot, and `produces` still carried `{paper}` unsubstituted, so the
+// page named a layer's prompt and its output and offered no way to open either. A row's paper
+// links to that paper's cell, which is where this layer's own output for it is rendered.
+import { papers, cell, titleOf, STATE_LABEL, VIEWS, type LayerDecl } from '../lib/pipeline';
+import { artifact, isDirectory } from '../lib/artifacts';
+import { source, records, document, output } from '../lib/layer-source';
 
 interface Props { layer: LayerDecl }
 const { layer } = Astro.props;
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const url = (p: string) => `${base}${p}/`;
 const rows = layer.scope === 'corpus'
   ? []
-  : papers.map(p => ({ paper: p, c: cell(p, layer.id)! })).filter(r => r.c);
+  : papers.map(p => ({ paper: p, c: cell(p, layer.id)! })).filter(r => r.c)
+      .map(r => ({
+        ...r,
+        // The artifact itself, where the run left one. A cell can be `current` with its file
+        // long gone, and a link that 404s is worse than none — so presence is read from disk.
+        art: r.c.produces.map(p => (records(p) || document(p)) ? artifact(p, base) : null)
+                          .find(Boolean) ?? null,
+      }));
 const counts: Record<string, number> = {};
 for (const r of rows) counts[r.c.state] = (counts[r.c.state] ?? 0) + 1;
+
+const reads = (layer.reads ?? []).map(r => source(r));
+
+// What the declared views actually resolve to, checked against a real artifact rather than
+// assumed from the declaration. `claim-tree` declares `list` and `table` and writes a directory
+// of markdown files; `replication` declares `table` and has never run. Saying "rendered above"
+// in either case would be the same kind of claim the inert `views` list was already making.
+const candidates = layer.scope === 'corpus'
+  ? [(layer.produces ?? []).filter(p => !p.includes('{paper}'))]
+  : rows.map(r => r.c.produces);
+const probes = candidates.map(ps => output(ps)).filter(o => o.path);
+const tabular = probes.find(o => (o.records?.records.length ?? 0) > 0);
+const prose = probes.find(o => o.document || (o.sections?.length ?? 0) > 0);
+
+// Why a view is not rendered matters more than that it is not: a layer that has never run and
+// a layer whose output is not the shape the view needs are different problems.
+const unrendered = (layer.produces ?? []).length === 0
+  ? 'declared, and this layer produces nothing yet'
+  : (layer.produces ?? []).every(isDirectory)
+    ? 'declared, and this layer writes a tree of claim files rather than one artifact'
+    : probes.length === 0
+      ? 'declared, and no run of this layer has left an artifact to render'
+      : 'declared, and this artifact is not the shape this view needs';
+
+const VIEW_NOTE = (v: string) => {
+  if (v === 'list' || v === 'table') {
+    return tabular
+      ? `rendered above, over the ${tabular.records!.records.length} ${tabular.records!.key ?? 'records'} in the artifact`
+      : unrendered;
+  }
+  if (v === 'document') return prose ? 'rendered above, from the artifact itself' : unrendered;
+  return VIEWS[v]?.where ?? 'declared, and nothing renders it yet';
+};
 
 const TONE: Record<string, string> = {
   current: 'text-emerald-700 dark:text-emerald-400',
@@ -33,6 +79,8 @@ const TONE: Record<string, string> = {
     <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">Across the corpus</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
       {Object.entries(counts).map(([s, n]) => `${n} ${STATE_LABEL[s as keyof typeof STATE_LABEL]}`).join(' · ')}
+      <span class="mx-1.5">·</span>
+      <span>a paper links to its own cell, where this layer's output for it is rendered</span>
     </p>
     <div class="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
       <table class="w-full text-sm border-collapse">
@@ -42,14 +90,15 @@ const TONE: Record<string, string> = {
             <th class="py-2.5 px-3 font-medium">State</th>
             <th class="py-2.5 px-3 font-medium">Version</th>
             <th class="py-2.5 px-3 font-medium">Last run</th>
-            <th class="py-2.5 px-4 font-medium">Data</th>
+            <th class="py-2.5 px-4 font-medium">Output</th>
+            <th class="py-2.5 px-4 font-medium">Cell</th>
           </tr>
         </thead>
         <tbody>
-          {rows.map(({ paper, c }) => (
+          {rows.map(({ paper, c, art }) => (
             <tr class="border-b border-gray-100 dark:border-gray-800 last:border-0">
               <td class="py-2.5 px-4">
-                <a href={url(`/papers/${paper}`)} class="text-gray-800 dark:text-gray-200 no-underline hover:text-amber-700 dark:hover:text-amber-400">
+                <a href={c.href} class="text-gray-800 dark:text-gray-200 no-underline hover:text-amber-700 dark:hover:text-amber-400">
                   {titleOf(paper).slice(0, 52)}{titleOf(paper).length > 52 ? '…' : ''}
                 </a>
                 {c.note && <span class="block text-xs text-gray-500 dark:text-gray-400 leading-snug">{c.note}</span>}
@@ -57,6 +106,13 @@ const TONE: Record<string, string> = {
               <td class={`py-2.5 px-3 font-mono text-xs whitespace-nowrap ${TONE[c.state]}`}>{STATE_LABEL[c.state]}</td>
               <td class="py-2.5 px-3 font-mono text-xs text-gray-500 dark:text-gray-400 tabular-nums">{c.v ? `v${c.v}` : '—'}</td>
               <td class="py-2.5 px-3 font-mono text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{c.ran?.slice(0, 10) ?? '—'}</td>
+              <td class="py-2.5 px-4 font-mono text-xs whitespace-nowrap">
+                {art
+                  ? <a href={art.href} target={art.downloadable ? undefined : '_blank'}
+                       rel={art.downloadable ? undefined : 'noopener'}
+                       class="text-amber-700 dark:text-amber-400 no-underline hover:underline">{art.name}</a>
+                  : <span class="text-gray-300 dark:text-gray-700">—</span>}
+              </td>
               <td class="py-2.5 px-4">
                 <a href={c.dataHref} class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">json</a>
               </td>
@@ -70,23 +126,55 @@ const TONE: Record<string, string> = {
 
 <section class="mb-10">
   <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Inputs and outputs</h2>
-  <dl class="text-sm space-y-3 m-0">
-    {(layer.reads ?? []).length > 0 && (
+  <dl class="text-sm space-y-4 m-0">
+    {reads.length > 0 && (
       <div>
-        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">Reads, besides its dependencies</dt>
-        <dd class="m-0 font-mono text-xs text-gray-700 dark:text-gray-300">{(layer.reads ?? []).join(' · ')}</dd>
+        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1.5">Reads, besides its dependencies</dt>
+        <dd class="m-0">
+          <ul class="list-none p-0 m-0 space-y-1">
+            {reads.map(f => (
+              <li>
+                <a href={f.href} target="_blank" rel="noopener"
+                   class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">{f.path}</a>
+                {f.exists
+                  ? <span class="text-xs text-gray-400 dark:text-gray-600"> · {f.lines} lines</span>
+                  : <span class="text-xs text-amber-700 dark:text-amber-400"> · declared, and not in the repository — it hashes to nothing, so it cannot make a run stale</span>}
+              </li>
+            ))}
+          </ul>
+        </dd>
       </div>
     )}
     {(layer.produces ?? []).length > 0 && (
       <div>
-        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">Produces</dt>
-        <dd class="m-0 font-mono text-xs text-gray-700 dark:text-gray-300">{(layer.produces ?? []).join(' · ')}</dd>
+        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1.5">Produces</dt>
+        <dd class="m-0">
+          <ul class="list-none p-0 m-0 space-y-1">
+            {(layer.produces ?? []).map(p => (
+              <li class="font-mono text-xs text-gray-700 dark:text-gray-300">{p}</li>
+            ))}
+          </ul>
+          {(layer.produces ?? []).some(p => p.includes('{paper}')) && layer.scope === 'paper' && (
+            <p class="text-xs text-gray-500 dark:text-gray-400 m-0 mt-1.5">
+              One per paper — the table above links each one that exists.
+            </p>
+          )}
+        </dd>
       </div>
     )}
     {(layer.views ?? []).length > 0 && (
       <div>
-        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">Views</dt>
-        <dd class="m-0 text-gray-700 dark:text-gray-300">{(layer.views ?? []).join(', ')}</dd>
+        <dt class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1.5">Views</dt>
+        <dd class="m-0">
+          <ul class="list-none p-0 m-0 space-y-1">
+            {(layer.views ?? []).map(v => (
+              <li class="text-xs">
+                <span class="font-mono text-gray-700 dark:text-gray-300">{v}</span>
+                <span class="text-gray-500 dark:text-gray-400">{` — ${VIEW_NOTE(v)}`}</span>
+              </li>
+            ))}
+          </ul>
+        </dd>
       </div>
     )}
   </dl>
@@ -100,6 +188,9 @@ const TONE: Record<string, string> = {
       diverge. <code>pipeline.py run</code> also runs the unmet dependencies first.
     </p>
     <pre class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-4 text-xs text-gray-700 dark:text-gray-300 overflow-x-auto m-0"><code>python3 scripts/pipeline.py run &lt;paper&gt; {layer.id}</code></pre>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2 m-0">
+      Underneath, that runs <code class="break-all">{layer.command}</code>.
+    </p>
   </section>
 )}
 

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -361,6 +361,8 @@
     },
     "layers": [
       {
+        "doc": "/pipeline/vocabulary/",
+        "how": "One file per claim: a YAML frontmatter block over a markdown body, carrying a uuid, a slug, the claim sentence, a `claim-type` and a `role`, the concepts it touches, an `epistemic` mark, and an `assertions` list naming the paper that asserts it and with what stance. Relations are frontmatter keys whose values are other claims' slugs, so the graph lives in the same files as the claims and there is no separate edge store to fall out of step with them.\nAlmost everything below reads or writes this, which is why a change here is never small. The document is a declared input of `relation-vocab` and `claim-tree` both, so editing it marks every tree in the corpus stale.\n",
         "id": "claim-format",
         "kind": "feature",
         "question": "What is a claim, and what may be said about one?",
@@ -374,6 +376,8 @@
         ]
       },
       {
+        "doc": "/pipeline/vocabulary/",
+        "how": "`scripts/relations.py` holds the vocabulary once \u2014 which relations exist, what each asserts, which pairs are oppositions \u2014 after four scripts each kept their own copy of the list and the four disagreed. `check_relations.py` runs that vocabulary over the corpus and is the gate `make check` enforces.\nWhat is undecided is not the implementation but the semantics: whether `supports` and `consistent-with` assert different things, and whether opposition is one relation or several. Until issue #19 closes, every count and every export downstream is provisional in the precise sense that it would change if the answer did.\n",
         "id": "relation-vocab",
         "issue": 19,
         "kind": "question",
@@ -385,7 +389,7 @@
         "reads": [
           "scripts/relations.py",
           "scripts/check_relations.py",
-          "exports/claim-relations.ttl"
+          "docs/schema-mapping/claim-relations.ttl"
         ],
         "scope": "corpus",
         "title": "Relation semantics",
@@ -395,6 +399,7 @@
         ]
       },
       {
+        "how": "`epistemic:` appears in every claim file and means two things at once. On some claims it records how strongly the evidence supports the proposition. On others it restates the claim's role \u2014 a hypothesis marked `weak` because hypotheses are hypotheses, not because anything about the evidence was measured.\nNothing runs here. There is no script and no output, which is what an open question looks like before anyone has built the machinery to evaluate it.\n",
         "id": "epistemic-vocab",
         "issue": 20,
         "kind": "question",
@@ -413,6 +418,7 @@
         "added": "2026-09-11",
         "command": "python3 scripts/prediction_outcome.py --write",
         "found": "`tests` is neutral by design, so a tree can record that a prediction was tested and never whether it was met. Of {{prediction_outcome_total}} predictions, {{prediction_outcome_unrecorded}} carry a `tests` edge and no outcome at all. Three wiring conventions are in use and they split by paper, not by case. And the vocabulary is asymmetric: `confirms` exists, nothing means \"the result came out against this\", so a failed prediction cannot be written down.\n",
+        "how": "The rule is mechanical. For each `role: prediction` claim it looks at the edges pointing in and out, and sorts the prediction by the shape of that wiring: a `tests` edge with a `confirms` beside it, a `tests` edge alone, a conjunction of several. It reads the graph and nothing else \u2014 not the paper, and not whether the prediction was in fact met.\nThat limit is the point of running it. Three wiring conventions are in use across the corpus and they split by paper rather than by case, so the buckets measure how the trees were written as much as what the papers found. Accepting the rule would mean accepting that reading, which is why the declaration is `proposed` and not accepted.\n",
         "id": "prediction-outcome",
         "issue": 28,
         "kind": "question",
@@ -437,7 +443,9 @@
       },
       {
         "command": "cd extract && python3 -m elife_extract.cli prepare --paper {paper} --doi {doi}",
+        "doc": "/docs/layers/#prepare--the-paper-the-readers-read",
         "group": "induction",
+        "how": "Fetches the paper and cuts it into the slices the three readers each get. For an eLife DOI that is JATS XML from the CDN, which gives labelled sections, typed figures and caption text; for anything else it is pdfplumber with regex section detection. Which path was taken is recorded in the output, because it constrains what the readers can possibly extract. The fetch is cached, so every later layer on the same paper runs offline and free.\nCheck the slice sizes when a paper extracts badly. A short `results` almost always means section detection failed, and then all three readers read the wrong text and every claim below them is wrong for the same single reason.\n",
         "id": "prepare",
         "kind": "step",
         "produces": [
@@ -456,7 +464,9 @@
       {
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli results-reader --paper {paper}",
+        "doc": "/docs/layers/#the-three-readers",
         "group": "induction",
+        "how": "Given the abstract and the results prose \u2014 and nothing else: no captions, no methods, no figures \u2014 it returns candidate claims, each with a role, a claim type, the panel where the prose names one, and the verbatim sentence it rests on.\nThe partition is what makes it worth running separately. It is the only reader positioned to see the paper's argument as an argument, so it is the one asked for hypotheses, predictions and synthesis rather than for numbers. It is also the reader most prone to flattening exactly that: where a paper derives a prediction from a hypothesis and then tests it, the easy output is one empirical claim, and the longest section of the prompt below exists to stop that.\n",
         "id": "results-reader",
         "kind": "candidate",
         "needs": [
@@ -479,7 +489,9 @@
       {
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli caption-reader --paper {paper}",
+        "doc": "/docs/layers/#the-three-readers",
         "group": "induction",
+        "how": "Given the figure and table captions, panel by panel, it returns the quantitative claims anchored to the panel that shows them. It does not see the results prose, so it cannot lift a number out of a sentence that summarises one, and it does not see the methods, so it cannot invent how a measurement was made.\nPanel assignment is where the three readers most often disagree, and it is the standing failure the evaluation harness measures.\n",
         "id": "caption-reader",
         "kind": "candidate",
         "needs": [
@@ -502,7 +514,9 @@
       {
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli structure-reader --paper {paper}",
+        "doc": "/docs/layers/#the-three-readers",
         "group": "induction",
+        "how": "Given the methods, the supplements and the section structure, it returns what the paper frames as its own conclusions, together with the methodological capabilities and the scope conditions the other two readers have no text for. Scope claims \u2014 what a study does and does not cover \u2014 appear almost nowhere else in a paper, so a pipeline without this reader does not under-report them, it loses them.\n",
         "id": "structure-reader",
         "kind": "candidate",
         "needs": [
@@ -525,7 +539,9 @@
       {
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli reconcile --paper {paper}",
+        "doc": "/docs/layers/#reconcile--which-candidates-survive",
         "group": "induction",
+        "how": "Reads the three readers' outputs from disk and aligns them into one draft table. Each surviving claim carries which readers proposed it and the evidence each quoted, and a confidence that is a fact about agreement rather than about the world: `high` where more than one reader surfaced it, `contested` where they surfaced it differently, `single-source` where one did.\nThis is the whole reason the readers run separately rather than as one pass over the paper. Agreement between three partitions is evidence; one agent reading everything produces a longer list and no way to tell which of it is load-bearing.\n",
         "id": "reconcile",
         "kind": "step",
         "needs": [
@@ -551,7 +567,9 @@
         "added": "2026-09-11",
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli external-review --paper {paper}",
+        "doc": "/docs/layers/#external-review--what-the-readers-systematically-miss",
         "group": "induction",
+        "how": "One Opus pass over the reconciled draft with the paper beside it, recovering what prose-level extraction systematically under-covers: the `prediction` and `hypothesis` roles, and multi- panel claims collapsed onto a single panel. Roughly two dollars and three minutes a paper, and it moved role agreement on the Headley round-trip from about 65% to about 96%.\nIt is not review in this file's sense \u2014 it is a second model, not a person, and it changes the artifact rather than approving a version of one. Running it is optional: `claim-tree` builds on this output where it exists and on the reconciled draft where it does not.\n",
         "id": "external-review",
         "kind": "step",
         "needs": [
@@ -574,7 +592,9 @@
       {
         "by_from": "model",
         "command": "cd extract && python3 -m elife_extract.cli edge-inference --paper {paper}",
+        "doc": "/docs/layers/#edge-inference--which-claims-depend-on-which",
         "group": "induction",
+        "how": "Given the draft's claims, numbered, it returns typed relations between them \u2014 the deductive spine, `entails` from a hypothesis to its predictions and `tests` back from the empirical result. Edges naming an unknown slug, or pointing at themselves, are dropped: an invented target is worse than a missing edge.\n`--dump-prompt` writes the exact request and exits, so that an analyst or a different model answers the question this layer would have asked rather than a paraphrase written from memory, and `--edges-json` feeds that answer back through the same validation. Edges are the part of a tree most easily lost to one failed call \u2014 every other stage can succeed and leave a paper with claims and no structure at all.\n",
         "id": "edge-inference",
         "kind": "step",
         "needs": [
@@ -598,7 +618,9 @@
       {
         "added": "2026-03",
         "command": "cd extract && python3 -m elife_extract.cli write --paper {paper}",
+        "doc": "/docs/layers/#write--the-claim-tree",
         "found": "Across {{papers}} papers the corpus holds {{claims}} claims and {{relations}} typed relations, using {{relation_types_used}} of the {{relation_types_defined}} defined relation types. The commonest role is `{{largest_role}}` at {{largest_role_n}} claims.\n",
+        "how": "Assigns each surviving claim a slug and a UUID, attaches the edges `edge-inference` produced, and writes one markdown file per claim into `claims/<paper>/` with the paper's `index.md` beside them. It calls no model and needs no credentials \u2014 the reasoning already happened upstream \u2014 but it does need those edges. Run it without them and the claims are written with no structure, and it says so.\nIt refuses to overwrite a non-empty paper directory. The claim files are edited afterwards by hand and by later layers, and a silent overwrite would discard work no ledger records.\n",
         "id": "claim-tree",
         "kind": "step",
         "needs": [
@@ -622,6 +644,7 @@
       {
         "added": "2026-09-10",
         "found": "A missing node does not only lose information, it misdirects the edges that would have pointed at it. Five eliminative relations were found aiming at claims their own paper asserts. {{dangling_rules_out}} eliminative edges still name prose that resolves to no claim.\n",
+        "how": "Adds the claims a paper argues against. Each is an ordinary claim file \u2014 prefixed `alt-` \u2014 whose `assertions` entry carries `stance: rejects` rather than `asserts`, so an alternative the paper rules out is a node in the graph like any other and an eliminative edge has something correct to point at.\nBefore these existed, a rejected alternative lived only as prose inside the claim that dismissed it, and an edge that should have pointed at it pointed at whatever claim was nearest.\n",
         "id": "stance",
         "kind": "feature",
         "needs": [
@@ -642,6 +665,8 @@
       {
         "added": "2026-09-11",
         "command": "cd extract && python3 -m elife_extract.cli verify-refs --paper {paper}",
+        "doc": "/docs/layers/#verify-refs--the-reference-check",
+        "how": "Two different operations under one name, and the difference is the whole of what this layer is worth. Where a `role: literature-context` claim already carries a top-level `doi:`, the layer confirms with CrossRef that it resolves to a real paper: that is the anti-hallucination check. Where there is no DOI, it extracts hints from the claim text and slug, queries CrossRef, and writes back the highest-scoring match above a threshold \u2014 a search, which can return a confident match to the wrong paper.\nThe report is what the layer produces; the confirmed DOIs land in the claim files themselves. Two earlier implementations both edited those files and disagreed about the result, and one of them recorded a fuzzy title match as a confirmed DOI.\n",
         "id": "reference-check",
         "kind": "feature",
         "needs": [
@@ -661,6 +686,7 @@
         ]
       },
       {
+        "how": "Cuts the abstract into sentences and asks of each which claims carry it, and of each claim whether any sentence of the abstract does. The output holds both directions, and the interesting column is the empty one: claims the tree holds that the abstract drops, and abstract sentences no claim accounts for.\nAn abstract is the paper's own summary of itself, so the difference between the two lists is the difference between what a paper found and what it advertises.\n",
         "id": "abstract-map",
         "kind": "step",
         "needs": [
@@ -679,6 +705,7 @@
       },
       {
         "added": "2026-09-11",
+        "how": "Restates the paper's argument from the claim graph alone \u2014 no abstract, no prose \u2014 and then holds that restatement against the abstract the authors wrote. Every sentence of the restatement carries the claims and edges it was built from, so any of it can be followed back to the nodes that produced it.\nIt is the closest thing in the pipeline to a test of whether the graph was worth building: if the tree carries the argument, a restatement from it should be recognisable as the same paper.\n",
         "id": "synthesis",
         "kind": "step",
         "needs": [
@@ -700,6 +727,7 @@
         "added": "2026-09-06",
         "command": "python3 verification/audit_run.py {paper}",
         "found": "{{eligible_with_record}} of {{eligible_claims}} claims that a re-run could settle carry a reproduction record, and their outcomes are not uniform. Observing the runs from outside also showed that most records were reached by reading a deposit rather than by running the paper's own script.\n",
+        "how": "Runs the paper's own deposited script under observation and records what it actually did \u2014 every path it opened, every value it computed \u2014 rather than what its output said it did. Nothing is taken from the script's own account of itself, because that is precisely what failed: the first script audited had a claim recorded `verified` while the function named in its record raised a shape-mismatch error, and a reproduction record naming a file the code never opened.\nThis is not replication. It re-runs the authors' code on the authors' data, so it can catch a record that does not match its own run and it cannot tell you whether the finding is true.\n",
         "id": "verification",
         "kind": "step",
         "needs": [
@@ -723,7 +751,9 @@
       {
         "added": "2026-09-10",
         "command": "cd extract && python3 -m elife_extract.cli coverage --paper {paper} --json ../coverage/{paper}.json",
+        "doc": "/docs/layers/#coverage-and-mark",
         "found": "G\u00e4deke first. The paper cut into spans and each adjudicated against the claim tree, which is how a tree is measured against its paper rather than against another tree. The mechanical match left 36 spans unaccounted for; 22 were the matcher being wrong and 14 were real.\n",
+        "how": "Takes its denominator from the paper rather than from the claim set. It builds the paper's own inventories \u2014 every panel, every table, every reported statistic \u2014 cuts the whole text into one-sentence spans, and asks of each span whether any claim accounts for it. Comparing two claim sets cannot see what this sees: two trees can agree perfectly over a third of a paper.\nIt calls no model, so it is free and fast enough to run corpus-wide. What it cannot do is tell a real gap from a string match that failed, which is what `adjudication` is for.\n",
         "id": "coverage",
         "kind": "step",
         "needs": [
@@ -742,6 +772,8 @@
         ]
       },
       {
+        "doc": "/docs/layers/#coverage-and-mark",
+        "how": "Reads the spans the mechanical match could not resolve and returns a verdict for each: the span is covered by a claim after all, it states a result no claim carries, or it asserts nothing at all. The verdicts are stored rather than recomputed \u2014 a verdict is a judgement about meaning, and re-running it would quietly produce a different one.\nOn G\u00e4deke the matcher left 36 spans unaccounted for. Adjudication found that 22 were the matcher being wrong and 14 were real.\n",
         "id": "adjudication",
         "kind": "judgement",
         "needs": [
@@ -763,6 +795,8 @@
       },
       {
         "command": "cd extract && python3 -m elife_extract.cli mark --paper {paper} --mapping ../mappings/{paper}.json -o ../marked/{paper}.marked.md",
+        "doc": "/docs/layers/#coverage-and-mark",
+        "how": "Writes the adjudicated verdicts into the document itself, as marks carrying each claim's UUID, so a gap is something a reader sees in the paper rather than a number in a report. A span that states no result says so; a span carrying a result no claim states is marked as a gap.\nThe marks are read straight back after writing and checked against the assignments they were written from. A marked document that cannot reproduce them is not a record of anything.\n",
         "id": "marks",
         "kind": "step",
         "needs": [
@@ -781,6 +815,7 @@
         ]
       },
       {
+        "how": "Nothing runs here, and the layer is declared so that the absence is a column rather than an omission. The `replicates` relation is defined in the schema and used zero times: no claim in this corpus has been checked against an independent study.\nIt is a different question from `verification`, answered by different evidence. Verification re-runs the authors' own code on their own data and can tell you the record matches the run. Only replication can tell you the finding holds.\n",
         "id": "replication",
         "kind": "step",
         "needs": [
@@ -799,6 +834,7 @@
         "command": "python3 scripts/export_mira.py {paper}",
         "found": "{{mira_carried}} of {{mira_relations}} relations reach the export, with {{mira_our_violations}} validation violations attributable to the encoding. The gaps that remain are specific: {{mira_lost}} paper-level scope relations the schema has no node for, and {{mira_verification_records}} verification records for which no interchange format has a node type at all.\n",
         "group": "interchange",
+        "how": "Writes two files and a gap report. `<paper>.mira.jsonld` is strict MIRA core, safe to hand to any MIRA reader; `<paper>.mira-extended.jsonld` is the same graph plus a `haak:` namespace carrying the structure MIRA has no vocabulary for; the gap report says what the strict file dropped, and why.\nThe split is the design rather than a compromise in it. MIRA can express roughly half of what a claim tree holds, and a single converted file either loses the other half quietly or emits something a strict reader rejects.\n",
         "id": "mira-export",
         "kind": "step",
         "needs": [
@@ -825,6 +861,7 @@
       {
         "command": "cd extract && python3 scripts/migrate_to_oxa.py ../claims/{paper} --output-dir ../exports",
         "group": "interchange",
+        "how": "Reads the claim files and writes the paper as one OXA Article JSON with a Claim node per claim. OXA is document-shaped rather than graph-shaped, so it keeps the text and the sectioning of a paper well and carries relations as properties of the nodes they leave.\nIt is also the input to the Discourse Graphs export, so anything lost here is lost there too, one conversion further along.\n",
         "id": "oxa-export",
         "kind": "step",
         "needs": [
@@ -847,6 +884,7 @@
       {
         "command": "cd extract && python3 scripts/export_discourse_graphs.py ../exports/{paper}.oxa.json --output ../exports/{paper}.dg.jsonld",
         "group": "interchange",
+        "how": "Maps the OXA nodes onto the Discourse Graphs Q/C/E/S ontology: hypothesis, prediction, synthesis and interpretation become `dg:Claim`; empirical and control become `dg:Evidence`; literature-context becomes `dg:Source`. A relation becomes `dg:supports` or `dg:opposedBy` where one of those fits, and carries its CiTO IRI as a typed annotation where neither does.\nFour node types for nine roles: the mapping is lossy by construction, and `formats-report` is where the amount is measured rather than asserted.\n",
         "id": "dg-export",
         "kind": "step",
         "needs": [
@@ -869,6 +907,7 @@
       {
         "command": "python3 scripts/formats_report.py {paper}",
         "group": "interchange",
+        "how": "Measures each conversion from the generated files rather than from the mapping tables. A mapping table says what a converter intends; the export says what it did, and those two came apart once already \u2014 the Discourse Graphs exporter looked for claims one level above where they sit and wrote a file with a single node, in valid JSON-LD that nothing would have flagged.\nThe markdown report is the artifact and the site renders it, so a figure on the page cannot disagree with the export it describes.\n",
         "id": "formats-report",
         "kind": "step",
         "needs": [

--- a/site/src/lib/artifacts.ts
+++ b/site/src/lib/artifacts.ts
@@ -68,5 +68,9 @@ export const artifacts = (paths: string[] | undefined, base: string): Artifact[]
   (paths ?? []).map(p => artifact(p, base));
 
 /** A directory of claim files is a tree, not a download. Declared paths that name one are
- *  reported as a location so the drawer can say so rather than offering a broken file. */
-export const isDirectory = (path: string) => !/\.[a-z0-9]+$/i.test(path);
+ *  reported as a location so the drawer can say so rather than offering a broken file.
+ *
+ *  A glob is the same case wearing an extension. `claims/{paper}/*.md` passed the extension
+ *  test and was offered as a link to a GitHub blob with a literal asterisk in it, which is a
+ *  404 on the one layer — the claim tree — whose output matters most. */
+export const isDirectory = (path: string) => path.includes('*') || !/\.[a-z0-9]+$/i.test(path);

--- a/site/src/lib/layer-source.ts
+++ b/site/src/lib/layer-source.ts
@@ -1,0 +1,210 @@
+// What a layer is made of, read from the repository at build.
+//
+// A layer page could say everything about a layer except the two things that define it: the
+// prompt or script it runs under, and what that produced. Both were rendered as bare paths —
+// `extract/prompts/results-reader.md`, `runs/{paper}/results-reader.output.json`, the second
+// still carrying its placeholder — so the page named its own definition and its own output
+// and showed neither.
+//
+// This reads both off disk during the build. Nothing is copied into src/data first, and there
+// is no generator to run: a prompt edited in the repository is a prompt changed on the site,
+// with no committed intermediate to go stale between them. The build's working directory is
+// site/, so the repository root is one level up — the same resolution lib/markdown.ts uses.
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { LayerDecl } from './pipeline';
+
+const ROOT = join(process.cwd(), '..');
+const REPO = 'https://github.com/zmainen/elife-claim-trees/blob/main';
+
+/** What kind of thing a declared input is, which decides how it can be shown. */
+export type SourceKind = 'prompt' | 'code' | 'data' | 'prose';
+
+export interface Source {
+  /** The declared path, with {paper} substituted where one was given. */
+  path: string;
+  kind: SourceKind;
+  /** False for a path the declaration names and the repository does not have. */
+  exists: boolean;
+  lines: number;
+  /** Full text — prompts and prose are shown whole; code is not. */
+  text?: string;
+  /** A code file's leading docstring or comment block: what it says it does. */
+  summary?: string;
+  href: string;
+}
+
+const kindOf = (p: string): SourceKind =>
+  /^extract\/prompts\//.test(p) ? 'prompt'
+    : /\.(py|js|ts|sh)$/.test(p) ? 'code'
+    : /\.(md|markdown|txt)$/.test(p) ? 'prose'
+    : 'data';
+
+/** A Python module docstring or a leading `#`/`//` comment block — the file's own account of
+ *  itself. Preferred over an excerpt of the code, which explains nothing to a reader who came
+ *  to find out what the layer does. */
+function header(text: string): string | undefined {
+  const doc = text.match(/^(?:#![^\n]*\n)?\s*(?:"""|''')([\s\S]*?)(?:"""|''')/);
+  if (doc) return doc[1].trim();
+  const lines: string[] = [];
+  for (const line of text.split('\n')) {
+    if (/^#!/.test(line)) continue;
+    const m = line.match(/^\s*(?:#|\/\/)\s?(.*)$/);
+    if (!m) break;
+    lines.push(m[1]);
+  }
+  const block = lines.join('\n').trim();
+  return block || undefined;
+}
+
+/** One declared path, resolved. */
+export function source(declared: string, paper?: string): Source {
+  const path = declared.replace(/\{paper\}/g, paper ?? '{paper}');
+  const abs = join(ROOT, path);
+  const exists = !paper && path.includes('{paper}') ? false : existsSync(abs);
+  const base: Source = {
+    path, kind: kindOf(path), exists, lines: 0, href: `${REPO}/${path}`,
+  };
+  if (!exists) return base;
+  const text = readFileSync(abs, 'utf8');
+  const lines = text.split('\n').length;
+  return base.kind === 'code'
+    ? { ...base, lines, summary: header(text) }
+    : { ...base, lines, text };
+}
+
+/** Everything a layer declares it reads besides its dependencies' outputs. */
+export const sources = (layer: LayerDecl, paper?: string): Source[] =>
+  (layer.reads ?? []).map(r => source(r, paper));
+
+// ── what a run produced ───────────────────────────────────────────────────────
+
+export interface Records {
+  /** The artifact these came out of. */
+  path: string;
+  /** The key holding them, when the file is an object; absent when it is a bare list. */
+  key?: string;
+  records: Record<string, unknown>[];
+  /** Field names in first-appearance order — the output's shape, read off the output. */
+  fields: string[];
+  /** The scalars beside the records: model, paper, counts. */
+  meta: Record<string, unknown>;
+}
+
+/** A markdown artifact, for the layers whose output is a document rather than a table. */
+export interface Document { path: string; text: string; truncated: boolean }
+
+/** The long text inside a JSON artifact — `prepare` writes the abstract, the results prose,
+ *  the captions and the methods as four fields of one file, and the only useful view of that
+ *  is the text itself. A field is a section when it is long enough to be prose rather than a
+ *  label. */
+export interface Section { key: string; text: string; chars: number }
+
+const DOC_CAP = 80_000;
+
+/** The records in a parsed artifact, if it has any.
+ *
+ * A bare list is the records. An object's records are its first array-of-objects value:
+ * `claims` for a reader, `spans` for an adjudication, `results` for a verification run,
+ * `items` for the prediction rule. Everything scalar beside them is the meta. A file with no
+ * such array — coverage's nested counts, the formats report's measurements — returns null,
+ * and the caller shows the meta alone rather than an empty table. */
+function parse(path: string, raw: string): Records | null {
+  let data: unknown;
+  try { data = JSON.parse(raw); } catch { return null; }
+
+  const isTable = (v: unknown): v is unknown[] =>
+    Array.isArray(v) && v.length > 0 && typeof v[0] === 'object' && v[0] !== null;
+
+  let records: unknown[] | null = null;
+  let key: string | undefined;
+  const meta: Record<string, unknown> = {};
+  const nested: [string, Record<string, unknown>][] = [];
+  if (Array.isArray(data)) {
+    records = data;
+  } else if (data && typeof data === 'object') {
+    for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
+      if (!records && isTable(v)) { records = v; key = k; }
+      else if (v === null || typeof v !== 'object') meta[k] = v;
+      else if (!Array.isArray(v)) nested.push([k, v as Record<string, unknown>]);
+    }
+    // One level down, when the top holds only counts. `coverage` writes its totals at the top
+    // and the spans nobody accounted for under `spans.orphans`, and those spans are the whole
+    // finding — a page that showed the counts and not the list showed the summary of a report
+    // instead of the report.
+    if (!records) {
+      for (const [k, obj] of nested) {
+        for (const [k2, v] of Object.entries(obj)) {
+          if (isTable(v)) { records = v; key = `${k}.${k2}`; break; }
+          if (v === null || typeof v !== 'object') meta[`${k}.${k2}`] = v;
+        }
+        if (records) break;
+      }
+    }
+  }
+  // Two is the threshold for calling an array a table. A one-element array is structure — the
+  // OXA export's single `children` entry, whose value is the whole document — and rendering it
+  // as a table of one row with a JSON blob in a cell tells a reader nothing the file would not
+  // have told them better.
+  if (!records || records.length < 2) {
+    return Object.keys(meta).length ? { path, records: [], fields: [], meta } : null;
+  }
+
+  const rows = records.filter(r => r && typeof r === 'object') as Record<string, unknown>[];
+  const fields: string[] = [];
+  for (const r of rows) for (const f of Object.keys(r)) if (!fields.includes(f)) fields.push(f);
+  return { path, key, records: rows, fields, meta };
+}
+
+/** Read one produced path as records, or null when it is not a JSON table. */
+export function records(path: string): Records | null {
+  const abs = join(ROOT, path);
+  if (!/\.json$/.test(path) || !existsSync(abs)) return null;
+  return parse(path, readFileSync(abs, 'utf8'));
+}
+
+/** Read one produced path as a document. */
+export function document(path: string): Document | null {
+  const abs = join(ROOT, path);
+  if (!/\.(md|markdown|txt)$/.test(path) || !existsSync(abs)) return null;
+  const text = readFileSync(abs, 'utf8');
+  return { path, text: text.slice(0, DOC_CAP), truncated: text.length > DOC_CAP };
+}
+
+const SECTION_MIN = 400;
+
+/** The prose fields of a JSON artifact, longest first. */
+export function sections(path: string): Section[] {
+  const abs = join(ROOT, path);
+  if (!/\.json$/.test(path) || !existsSync(abs)) return [];
+  let data: unknown;
+  try { data = JSON.parse(readFileSync(abs, 'utf8')); } catch { return []; }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return [];
+  return Object.entries(data as Record<string, unknown>)
+    .filter(([, v]) => typeof v === 'string' && v.length >= SECTION_MIN)
+    .map(([key, v]) => ({ key, text: v as string, chars: (v as string).length }));
+}
+
+/** Whatever this cell produced that can be shown, and the path it came from.
+ *
+ * The path is returned even when nothing in the file can be rendered, because the link is
+ * worth having on its own: the previous version of this page showed neither the output nor a
+ * way to reach it. */
+export function output(produces: string[]):
+    { path?: string; records?: Records; document?: Document; sections?: Section[] } {
+  for (const p of produces) {
+    const d = document(p);
+    if (d) return { path: p, document: d };
+    const r = records(p);
+    if (r) return { path: p, records: r, sections: sections(p) };
+    if (existsSync(join(ROOT, p))) return { path: p };
+  }
+  return {};
+}
+
+/** Bytes on disk, for a path the site links but does not serve. */
+export const size = (path: string): number | null => {
+  const abs = join(ROOT, path);
+  return existsSync(abs) ? statSync(abs).size : null;
+};

--- a/site/src/lib/markdown.ts
+++ b/site/src/lib/markdown.ts
@@ -20,6 +20,8 @@ import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
 import rehypeShiki from '@shikijs/rehype';
 import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+import GithubSlugger from 'github-slugger';
 
 // Paths resolve against site/, which is process.cwd() at build.
 const ROOT = join(process.cwd(), '..');
@@ -72,11 +74,32 @@ export function readDoc(relPath: string): string {
   });
 }
 
+/** Give every heading an id, so a section can be linked to.
+ *
+ *  The layer declarations point at the section of /docs that explains how to run each layer,
+ *  and a link to a 200-line page is a link to its top: the reader arrives at "The layer
+ *  runners" and has to find `reconcile` themselves. Ids are the GitHub slug of the heading
+ *  text, which is the spelling anyone writing a link would guess, and the one the markdown
+ *  files already use among themselves. */
+function headingIds() {
+  return (tree: any) => {
+    const slugger = new GithubSlugger();
+    visit(tree, 'element', (node: any) => {
+      if (!/^h[1-6]$/.test(node.tagName) || node.properties?.id) return;
+      const text: string[] = [];
+      visit(node, 'text', (t: any) => { text.push(t.value); });
+      const slug = slugger.slug(text.join(''));
+      if (slug) node.properties = { ...node.properties, id: slug };
+    });
+  };
+}
+
 // allowDangerousHtml is fine here — the source is the repository's own prose.
 const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkRehype, { allowDangerousHtml: true })
+  .use(headingIds)
   .use(rehypeShiki, { theme: 'github-dark', fallbackLanguage: 'text' })
   .use(rehypeStringify, { allowDangerousHtml: true });
 

--- a/site/src/lib/pipeline.ts
+++ b/site/src/lib/pipeline.ts
@@ -29,6 +29,15 @@ export interface LayerDecl {
   views?: string[];
   command?: string;
   issue?: number;
+  /** The layer this one passes judgement on. Set only on `judgement` layers. */
+  reviews?: string;
+  /** How it works, in prose: what it is given, what it returns, and what it gets wrong.
+   *  The declaration's `question` says why the layer exists; this says how it answers. A
+   *  layer whose prompt or script carries that account already leaves it unset rather than
+   *  restating it — see /docs/layers for the narrative the `doc` link points at. */
+  how?: string;
+  /** A site path to the narrative documentation for this layer, deep-linked to its section. */
+  doc?: string;
   /** Lifecycle of the declaration itself (#31). A layer's declaration is a proposal: it says
    *  a step should exist and what it does, and at some point that is accepted. Absent means
    *  unstated — not accepted. Only `proposed` is rendered, so an undeclared status never
@@ -243,6 +252,20 @@ export function resolve(text: string): string {
 export function approvedCells(): Cell[] {
   return papers.flatMap(p => cells(p).filter(c => c.approved?.applies));
 }
+
+/** What each declared view is, and where it is rendered.
+ *
+ *  `views` was a list of words printed on the page and implemented nowhere, which reads as a
+ *  feature to anyone who has not tried to use one. Every view named here says which component
+ *  draws it; a view with no entry is declared and not built, and the page says so rather than
+ *  printing the word and leaving the reader to find out.
+ */
+export const VIEWS: Record<string, { label: string; where: string }> = {
+  document:   { label: 'document', where: 'rendered above, where the layer writes prose' },
+  graph:      { label: 'graph', where: 'on the paper page, as the claim graph' },
+  comparison: { label: 'comparison', where: 'on the cell page, for the layers that have one' },
+  overlap:    { label: 'overlap', where: 'on the induction page, as reader agreement' },
+};
 
 export const STATE_LABEL: Record<CellState, string> = {
   current: 'current',

--- a/site/src/pages/papers/[paper]/[layer].astro
+++ b/site/src/pages/papers/[paper]/[layer].astro
@@ -7,14 +7,14 @@
 // to the drawer — rather than moving every claim URL to make room.
 import Layout from '../../../layouts/Layout.astro';
 import LayerState from '../../../components/LayerState.astro';
+import LayerDefinition from '../../../components/LayerDefinition.astro';
+import LayerOutput from '../../../components/LayerOutput.astro';
 import AbstractAlignment from '../../../components/AbstractAlignment.astro';
 import ArgumentFromGraph from '../../../components/ArgumentFromGraph.astro';
 import { getCollection, render } from 'astro:content';
 import { paperLayers, byId, cell, STATE_LABEL } from '../../../lib/pipeline';
 import { artifacts, isDirectory } from '../../../lib/artifacts';
 import corpus from '../../../data/claims.json';
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
 
 export async function getStaticPaths() {
   const formats = await getCollection('formats');
@@ -77,22 +77,11 @@ const rendered = report ? await render(report) : null;
 const showReport = layerId === 'formats-report' && rendered && c.state !== 'absent';
 const Content = rendered?.Content;
 
-// The layer's own output, read from the artifact it produced. A reader's claims and the
-// quote each was found in are the provenance this whole corpus rests on, and they were only
-// ever visible for one paper on one narrated page. They belong on the cell.
-function readRun(paths: string[]) {
-  for (const rel of paths) {
-    if (!rel.endsWith('.output.json')) continue;
-    const abs = join(process.cwd(), '..', rel);
-    if (!existsSync(abs)) continue;
-    try {
-      const d = JSON.parse(readFileSync(abs, 'utf-8'));
-      if (Array.isArray(d?.claims)) return { path: rel, model: d.model, agent: d.agent, claims: d.claims };
-    } catch { /* a malformed run record is not worth failing the page over */ }
-  }
-  return null;
-}
-const run = readRun(c.produces);
+// What the layer produced is rendered by the shared component, in the views the layer
+// declares. This page used to read the artifact itself, and only recognised a file named
+// `*.output.json` holding a key called `claims` — so the three readers and the reconciler
+// showed their output and the other eighteen layers showed none of theirs, on a page whose
+// heading promised it.
 
 const TONE: Record<string, string> = {
   current: 'text-emerald-700 dark:text-emerald-400 border-emerald-500 dark:border-emerald-600',
@@ -209,32 +198,11 @@ const TONE: Record<string, string> = {
       </section>
     )}
 
-    {run && (
-      <section class="mb-10">
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          What it produced <span class="font-mono text-sm text-gray-400 dark:text-gray-500">{run.claims.length} claims</span>
-        </h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-5">
-          Read from <code>{run.path}</code>{run.model ? <> · answered by <code>{run.model}</code></> : null}.
-          Each claim as this agent wrote it, with the passage it was found in.
-        </p>
-        <ol class="list-none p-0 m-0 space-y-4">
-          {run.claims.map((cl: any, i: number) => (
-            <li class="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
-              <p class="text-[15px] text-gray-800 dark:text-gray-200 m-0 leading-snug">{cl.claim}</p>
-              <p class="font-mono text-[11px] text-gray-500 dark:text-gray-400 m-0 mt-1">
-                {[cl.role, cl.claim_type, cl.panel, cl.confidence].filter(Boolean).join(' · ')}
-              </p>
-              {cl.evidence && (
-                <p class="text-xs text-gray-600 dark:text-gray-400 m-0 mt-1.5 italic leading-snug">
-                  “{String(cl.evidence).slice(0, 320)}{String(cl.evidence).length > 320 ? '…' : ''}”
-                </p>
-              )}
-            </li>
-          ))}
-        </ol>
-      </section>
+    {!showReport && !abstractMapping && !synthesisBlock && (
+      <LayerOutput layer={layer} paper={paper.slug} produces={c.produces} />
     )}
+
+    <LayerDefinition layer={layer} paper={paper.slug} />
 
     {c.produces.length > 0 && (
       <section class="mb-10">

--- a/site/src/pages/pipeline/[layer].astro
+++ b/site/src/pages/pipeline/[layer].astro
@@ -1,18 +1,27 @@
 ---
 // One layer, in general.
 //
-// The same question asked of every paper: what it is, what it rests on, what it feeds, and
-// where it has and has not been run. A paper's own instance lives on the paper page; this is
-// the corpus altitude of the same cell.
+// The same question asked of every paper: what it is, how it is defined, what it produced,
+// what it rests on, what it feeds, and where it has and has not been run. A paper's own
+// instance lives on the paper page; this is the corpus altitude of the same cell.
+//
+// It used to stop at the declaration. The prompt that defines a reader was a path, its output
+// was a path with `{paper}` still in it, and `views: [list, table]` was two words. A page can
+// name a layer's definition or it can show it, and naming it is what a directory listing
+// does — so the prompt is rendered here in full, and one paper's output is rendered beneath
+// it in the views the layer declares.
 //
 // A layer with more to say than the declaration holds gets a static route of its own —
 // pipeline/mira-export.astro, pipeline/formats-report.astro — which Astro prefers over this
-// dynamic one. Those pages use the same two components, so a bespoke page is depth behind the
+// dynamic one. Those pages use the same components, so a bespoke page is depth behind the
 // general surface rather than an escape from it.
 import Layout from '../../layouts/Layout.astro';
 import LayerHeader from '../../components/LayerHeader.astro';
+import LayerDefinition from '../../components/LayerDefinition.astro';
+import LayerOutput from '../../components/LayerOutput.astro';
 import LayerState from '../../components/LayerState.astro';
-import { layers } from '../../lib/pipeline';
+import { layers, papers, cell, shortOf } from '../../lib/pipeline';
+import { output } from '../../lib/layer-source';
 
 export function getStaticPaths() {
   return layers.map(l => ({ params: { layer: l.id }, props: { layer: l } }));
@@ -20,12 +29,37 @@ export function getStaticPaths() {
 
 const { layer } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+// A worked example: the first paper whose run left a file this site can render. Most layers
+// have exactly one — nine of the ten papers predate the ledger — and showing that one is the
+// difference between a page that describes an output format and a page that shows the output.
+const example = layer.scope === 'corpus'
+  ? null
+  : papers.map(p => cell(p, layer.id))
+          .find(c => c && Object.keys(output(c.produces)).length > 0) ?? null;
+const corpusOutput = layer.scope === 'corpus'
+  ? (layer.produces ?? []).filter(p => !p.includes('{paper}'))
+  : [];
 ---
 
 <Layout title={`${layer.title} — pipeline`} description={layer.question}>
   <div class="site-frame column py-12">
     <LayerHeader layer={layer} />
+    <LayerDefinition layer={layer} />
+
+    {example && (
+      <LayerOutput layer={layer} paper={example.paper} produces={example.produces}
+                   heading="What it produces"
+                   note={`One paper, as the worked example — ${shortOf(example.paper)}, v${example.v ?? 1}.`} />
+    )}
+    {corpusOutput.length > 0 && (
+      <LayerOutput layer={layer} paper="corpus" produces={corpusOutput}
+                   heading="What it produces"
+                   note="This layer runs across the corpus, so there is one output rather than one per paper." />
+    )}
+
     <LayerState layer={layer} />
+
     <footer class="pt-6 border-t border-gray-100 dark:border-gray-800 text-sm">
       <a href={`${base}/pipeline/`} class="text-gray-500 dark:text-gray-400 no-underline hover:text-gray-700 dark:hover:text-gray-300">← all layers</a>
     </footer>

--- a/site/src/pages/pipeline/formats-report.astro
+++ b/site/src/pages/pipeline/formats-report.astro
@@ -3,6 +3,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import Layout from '../../layouts/Layout.astro';
 import LayerHeader from '../../components/LayerHeader.astro';
+import LayerDefinition from '../../components/LayerDefinition.astro';
 import LayerState from '../../components/LayerState.astro';
 import { byId } from '../../lib/pipeline';
 import corpus from '../../data/claims.json';
@@ -56,6 +57,8 @@ const layer = byId['formats-report'];
   <div class="site-frame column py-16">
 
     <LayerHeader layer={layer} />
+
+    <LayerDefinition layer={layer} />
 
     <div class="space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-10">
       <p>

--- a/site/src/pages/pipeline/mira-export.astro
+++ b/site/src/pages/pipeline/mira-export.astro
@@ -7,6 +7,7 @@
 // One page about MIRA, not two.
 import Layout from '../../layouts/Layout.astro';
 import LayerHeader from '../../components/LayerHeader.astro';
+import LayerDefinition from '../../components/LayerDefinition.astro';
 import LayerState from '../../components/LayerState.astro';
 import { byId } from '../../lib/pipeline';
 
@@ -18,6 +19,8 @@ const layer = byId['mira-export'];
   <div class="site-frame column py-12">
 
     <LayerHeader layer={layer} />
+
+    <LayerDefinition layer={layer} />
 
     <div class="border-l-2 border-amber-400 dark:border-amber-600 pl-4 mb-10">
       <p class="text-sm text-gray-700 dark:text-gray-300 m-0 leading-relaxed">

--- a/site/src/pages/pipeline/prediction-outcome.astro
+++ b/site/src/pages/pipeline/prediction-outcome.astro
@@ -13,6 +13,7 @@
 // to drift from the first.
 import Layout from '../../layouts/Layout.astro';
 import LayerHeader from '../../components/LayerHeader.astro';
+import LayerDefinition from '../../components/LayerDefinition.astro';
 import LayerState from '../../components/LayerState.astro';
 import { byId } from '../../lib/pipeline';
 import { readFileSync } from 'fs';
@@ -60,6 +61,7 @@ const BAR: Record<string, string> = {
         description="A proposed layer: did the paper's predictions come out, and does the tree say so?">
   <div class="site-frame column py-12">
     <LayerHeader layer={layer} />
+    <LayerDefinition layer={layer} />
 
     <!-- What is being asked of a reader. First, because it changes how everything below is read. -->
     <section class="mb-10 border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 rounded-lg p-5">

--- a/site/src/pages/pipeline/relation-vocab.astro
+++ b/site/src/pages/pipeline/relation-vocab.astro
@@ -15,6 +15,7 @@
 // static, and a judgement that lived only in a browser would be lost.
 import Layout from '../../layouts/Layout.astro';
 import LayerHeader from '../../components/LayerHeader.astro';
+import LayerDefinition from '../../components/LayerDefinition.astro';
 import LayerState from '../../components/LayerState.astro';
 import { byId } from '../../lib/pipeline';
 import { readFileSync } from 'fs';
@@ -73,6 +74,9 @@ const layer = byId['relation-vocab'];
 
     
     <LayerHeader layer={layer} />
+
+    
+    <LayerDefinition layer={layer} />
 
 
     <div class="max-w-3xl space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed mb-10">


### PR DESCRIPTION
`/pipeline/results-reader/` named three things and showed none of them. The prompt that defines the layer was the string `extract/prompts/results-reader.md`. Its output was the string `runs/{paper}/results-reader.output.json` — placeholder and all, resolved for no paper and linked for none. And `views: list, table` was two words of prose over a feature implemented nowhere, which reads as a feature to anyone who has not tried to use one.

All three are real now, for every layer rather than for that one.

## The prompt is the layer, so the page shows it

Rendered in full from the committed file at build. There is no generator and no copy in `src/data`: editing a prompt changes the page, with no committed intermediate to go stale between them. A layer that runs a script gets that script's own docstring and a link to the source instead — 600 lines of Python on a layer page buries the paragraph a reader came for.

## The output is read from the artifact that produced it

One paper as the worked example on the layer page, this paper's own run on the cell page — the same component, because it is the same question at two altitudes. The shape is read off the file rather than configured per layer, so a reader's claims, an adjudication's spans, a verification's results and the coverage spans nobody accounted for all render without the component knowing what any of them are.

The cell page used to do this itself, and recognised exactly one shape: a file named `*.output.json` holding a key called `claims`. Four layers had output on that page and eighteen did not, under a heading that promised otherwise.

## Declared views are drawn, or say why not

`list` and `table` are real, with a switch between them, and each is drawn because the declaration asks for it. Where a declared view is not drawn, the page says which of the reasons it is — checked against a real artifact rather than asserted:

- the layer produces nothing yet (`replication`, `epistemic-vocab`)
- no run has left an artifact to render (`external-review`)
- the artifact is not the shape the view needs (`oxa-export`, `dg-export`)
- it writes a tree of claim files rather than one file (`claim-tree`, `stance`)

Views that live elsewhere — the graph on the paper page, the overlap on the induction page — say where.

## Every path on the page is an address

`reads` links to its source with its length, `produces` resolves per paper in the corpus table, and each paper row links to its own cell rather than to the paper.

## Two fields the declaration could not carry

- **`how:`** — what the layer is given, what it returns, and what it gets wrong. `question` says why a layer exists; this says how it answers. Written for all 25 layers.
- **`doc:`** — the section of `/docs` that explains how to run it. Headings in rendered repository markdown now carry ids, so these deep-link; all 14 are checked against the built HTML.

## Fixed in passing, found by rendering what was declared

- `relation-vocab` declared `exports/claim-relations.ttl`, which does not exist. A missing input hashes to `None`, so the layer was declared to depend on a file it was not in fact tracking — editing the relation schema could never have marked it stale. The file is `docs/schema-mapping/claim-relations.ttl`.
- `claims/{paper}/*.md` passed the "has an extension" test and was offered as a GitHub blob link with a literal asterisk in it — a 404 on the one layer whose output matters most.
- `make fresh`'s own failure message ran `stale` and `moved` as shell commands.

## Checks

`make check`, `make fresh` and `npm run build` are clean. The four `Could not render /pipeline/<layer> … conflicts with higher priority route` warnings are the pre-existing bespoke pages winning over the dynamic route, as intended; those four now carry the same definition block as the rest.

One change worth a second look: `.claude/launch.json` gains `autoPort: true`, so the preview can start when another session already holds 4321. It is a tracked file and a no-op when the port is free — say the word and I will drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
