### PR TITLE
A backfilled cell keeps the version, date and model it recorded

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -307,6 +307,21 @@ def state(decl: dict | None = None, slugs: list[str] | None = None) -> dict:
                 # current"; saying `unrecorded` is the honest answer and is what the state
                 # means. The artifact may be perfectly good.
                 st = ABSENT if not produced else "unrecorded"
+
+                # What the entry *does* carry is kept. Declining to assert inputs a backfill
+                # never observed is the point of #30; discarding the version, the date and the
+                # model alongside them was not. Thirteen of Gaedeke's fifteen `unrecorded`
+                # cells have an entry naming all three, and the site rendered every one of
+                # them as a bare "no run recorded" directly above the artifact it names —
+                # which reads as nothing having happened, in a corpus where something did.
+                #
+                # `by` is written as the literal "unrecorded" when the backfill could not tell
+                # who answered, so it is dropped here rather than rendered as an author.
+                if run:
+                    by = run.get("by")
+                    cells[lid] = {"state": st, "v": run["v"], "ran": run.get("ran"),
+                                  "note": run.get("note"), "backfilled": True,
+                                  "by": None if by == "unrecorded" else by}
             else:
                 moved = [i["path"] for i in run.get("in", []) if digest(i["path"]) != i["sha"]]
                 lost = [o["path"] for o in run.get("out", []) if not digest(o["path"])]

--- a/site/src/components/LayerDrawer.tsx
+++ b/site/src/components/LayerDrawer.tsx
@@ -74,7 +74,18 @@ function CellBlock({ c, showPaper }: { c: CellView; showPaper: boolean }) {
           {showPaper ? c.stateLabel : ''}{c.v ? ` · v${c.v}` : ''}{c.ran ? ` · ${c.ran}` : ''}
         </span>
       </div>
+      {c.by && (
+        <p className="text-[11.5px] text-gray-500 dark:text-gray-400 m-0 leading-snug">
+          answered by <code className="text-[11px]">{c.by}</code>
+        </p>
+      )}
       {c.note && <p className="text-[11.5px] text-gray-500 dark:text-gray-400 m-0 mb-1 leading-snug">{c.note}</p>}
+      {c.backfilled && (
+        <p className="text-[11.5px] text-gray-500 dark:text-gray-400 m-0 mb-1 leading-snug">
+          The version and the date are real; the inputs were never hashed, so nothing can say
+          whether this is still current.
+        </p>
+      )}
       {has && (
         <ul className="list-none p-0 m-0 mt-1">
           {c.artifacts.map(a => <ArtifactRow key={a.path} a={a} />)}

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -7483,7 +7483,12 @@
     "state": {
       "artiushin-2026-spider-atlas": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T03:48:50Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -7502,12 +7507,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:48:01Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -7516,7 +7526,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -7563,10 +7578,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -7620,7 +7640,12 @@
       },
       "bouyeure-2026-fear-rsa": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T03:48:50Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -7639,12 +7664,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:48:01Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -7653,7 +7683,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -7700,10 +7735,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -7752,12 +7792,22 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "ejdrup-2026-dopamine": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T00:17:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -7776,12 +7826,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-26T15:52:15Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -7790,7 +7845,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -7837,10 +7897,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -7895,28 +7960,53 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "gadeke-2026-guilt-insula": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T03:48:50Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-09T11:55:22Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "caption-reader": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": "deepseek/deepseek-chat",
+          "note": "backfilled from runs/manifest.json",
+          "ran": "2026-09-10",
+          "state": "unrecorded",
+          "v": 1
         },
         "claim-format": {
           "scope": "corpus",
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:07:29Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "external-review"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "by": "scripts/pipeline.py run",
@@ -7928,10 +8018,20 @@
           "v": 1
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": "claude-opus-5 (agent, not the configured backend)",
+          "note": "backfilled from runs/manifest.json",
+          "ran": "2026-09-10",
+          "state": "unrecorded",
+          "v": 1
         },
         "epistemic-vocab": {
           "scope": "corpus",
@@ -7950,7 +8050,12 @@
           "v": 3
         },
         "marks": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:56:15Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "mira-export": {
           "by": "scripts/pipeline.py run",
@@ -7962,7 +8067,12 @@
           "v": 3
         },
         "oxa-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -7978,7 +8088,12 @@
           "v": 1
         },
         "reconcile": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:40:52Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "reference-check": {
           "state": "absent"
@@ -7991,13 +8106,28 @@
           "state": "absent"
         },
         "results-reader": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": "deepseek/deepseek-chat",
+          "note": "backfilled from runs/manifest.json",
+          "ran": "2026-09-10",
+          "state": "unrecorded",
+          "v": 1
         },
         "stance": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T16:37:02Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "structure-reader": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": "deepseek/deepseek-chat",
+          "note": "backfilled from runs/manifest.json",
+          "ran": "2026-09-10",
+          "state": "unrecorded",
+          "v": 1
         },
         "summaries": {
           "state": "unrecorded"
@@ -8006,12 +8136,22 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:07:29Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "headley-2026-inhibitory-rhythms": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-19T22:58:52Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -8030,12 +8170,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:48:01Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -8044,7 +8189,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8091,10 +8241,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8143,12 +8298,22 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "kammer-2026-foveal-feedback": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-19T22:58:52Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -8167,12 +8332,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:48:01Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -8181,7 +8351,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8228,10 +8403,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8285,7 +8465,12 @@
       },
       "kolb-2026-igabasnfr2": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T04:35:53Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent"
@@ -8301,12 +8486,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:11:33Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "by": "scripts/pipeline.py run",
@@ -8321,7 +8511,12 @@
           "v": 1
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8365,7 +8560,12 @@
           "v": 3
         },
         "oxa-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8399,7 +8599,12 @@
           ]
         },
         "stance": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:11:33Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "structure-reader": {
           "state": "absent",
@@ -8414,12 +8619,22 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "rozak-2026-neurovascular-dl": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T04:35:53Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent"
@@ -8435,12 +8650,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:11:33Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "by": "scripts/pipeline.py run",
@@ -8455,7 +8675,12 @@
           "v": 1
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8499,7 +8724,12 @@
           "v": 3
         },
         "oxa-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8533,7 +8763,12 @@
           ]
         },
         "stance": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:11:33Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "structure-reader": {
           "state": "absent",
@@ -8553,7 +8788,12 @@
       },
       "scheller-2026-self-prioritization": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T04:35:53Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -8572,12 +8812,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -8586,7 +8831,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8633,10 +8883,15 @@
           "v": 3
         },
         "oxa-export": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T12:50:38Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "stance"
-          ]
+          ],
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8685,12 +8940,22 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       },
       "wengert-2026-kcnc1": {
         "abstract-map": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-04-20T04:35:53Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "adjudication": {
           "state": "absent",
@@ -8709,12 +8974,17 @@
           "state": "current"
         },
         "claim-tree": {
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T09:48:01Z",
           "state": "unrecorded",
           "unrecorded_upstream": [
             "reconcile",
             "external-review",
             "edge-inference"
-          ]
+          ],
+          "v": 1
         },
         "coverage": {
           "state": "absent",
@@ -8723,7 +8993,12 @@
           ]
         },
         "dg-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "edge-inference": {
           "state": "absent",
@@ -8767,7 +9042,12 @@
           "v": 3
         },
         "oxa-export": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-11T08:12:34Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "prediction-outcome": {
           "scope": "corpus",
@@ -8801,7 +9081,12 @@
           ]
         },
         "stance": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:11:33Z",
+          "state": "unrecorded",
+          "v": 1
         },
         "structure-reader": {
           "state": "absent",
@@ -8816,7 +9101,12 @@
           "state": "unrecorded"
         },
         "verification": {
-          "state": "unrecorded"
+          "backfilled": true,
+          "by": null,
+          "note": "backfilled from the artifact on disk",
+          "ran": "2026-09-10T17:20:18Z",
+          "state": "unrecorded",
+          "v": 1
         }
       }
     }

--- a/site/src/lib/explorer.ts
+++ b/site/src/lib/explorer.ts
@@ -34,6 +34,10 @@ export interface CellView {
   v: number | null;
   ran: string | null;
   note: string | null;
+  /** Who answered: the model, for a layer a model answers. */
+  by: string | null;
+  /** The entry is a backfill — real version, real date, inputs never hashed. */
+  backfilled: boolean;
   href: string;
   dataHref: string;
   artifacts: Artifact[];
@@ -89,6 +93,8 @@ const cellView = (paper: string, layer: LayerDecl, base: string): CellView | nul
     v: c.v ?? null,
     ran: c.ran?.slice(0, 10) ?? null,
     note: c.note ?? null,
+    by: c.by ?? null,
+    backfilled: Boolean(c.backfilled),
     href: c.href,
     dataHref: c.dataHref,
     artifacts: artifacts(produced.filter(p => !isDirectory(p)), base, { paper, layer: layer.id }),

--- a/site/src/lib/pipeline.ts
+++ b/site/src/lib/pipeline.ts
@@ -64,6 +64,9 @@ export interface Cell {
   blockedBy?: string[];
   /** Upstream layers with no ledger entry. Not a fault in this cell; a gap in its account. */
   unrecordedUpstream?: string[];
+  /** The entry is a backfill: it records that the artifact exists, not that a run was
+   *  watched. Its version, date and author are real; its inputs were never hashed. */
+  backfilled?: boolean;
   /** Artifact paths for this cell, resolved for this paper. */
   produces: string[];
   /** The command that would fill it, with {paper} and {doi} substituted. */
@@ -151,6 +154,7 @@ export function cell(paper: string, layerId: string): Cell | null {
     lost: raw.lost?.length ? raw.lost : undefined,
     blockedBy: raw.blocked_by,
     unrecordedUpstream: raw.unrecorded_upstream,
+    backfilled: raw.backfilled,
     versions: history(paper, layerId),
     approved: raw.approved,
     produces: (layer.produces ?? []).map(p => fill(p, paper)),
@@ -185,11 +189,16 @@ export function inState(...states: CellState[]): Cell[] {
  *
  *  `absent` is the only state that is genuinely empty. What is checkable is counted
  *  separately, on /pipeline, where the distinction is the subject rather than a side effect. */
-export function fill_of(paper: string): { done: number; total: number } {
+export function fill_of(paper: string): { done: number; total: number; observed: number } {
   const cs = cells(paper);
   return {
     done: cs.filter(c => c.state !== 'absent').length,
     total: cs.length,
+    // The other half of the sentence. `done` counts answers and `observed` counts the runs
+    // that can still be checked, and a page that prints the first without the second reads as
+    // a contradiction beside cells that say no run was observed — which is what Gaedeke's
+    // "18/21 layers" did, over fifteen of them.
+    observed: cs.filter(c => c.state === 'current' || c.state === 'stale' || c.state === 'blocked').length,
   };
 }
 
@@ -286,7 +295,12 @@ export const STATE_LABEL: Record<CellState, string> = {
   // `unrecorded` named the ledger's gap rather than the reader's question, and the word does
   // not say which of the two it means — the file is missing, or the account of it is. It is
   // the second: the artifact is there and may be perfectly good.
-  unrecorded: 'no run recorded',
+  //
+  // "no run recorded" then overstated the gap in the other direction. Most of these cells have
+  // a ledger entry naming a version, a date and the model that answered; what the entry does
+  // not have is the inputs, because the run was reconstructed rather than watched. The label
+  // says which of those two things is missing.
+  unrecorded: 'run not observed',
 };
 
 /** What each state means, in one line. The label is a word on a chip; a reader meeting it for

--- a/site/src/pages/papers/[paper].astro
+++ b/site/src/pages/papers/[paper].astro
@@ -166,7 +166,12 @@ const tabs = [
          somebody else's work. -->
     <div class="mb-6 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
       <span class="tabular-nums">{paperData.claimCount} claims</span>
-      <span class="tabular-nums">{fill_of(paperData.slug).done}/{fill_of(paperData.slug).total} layers</span>
+      <span class="tabular-nums" title="A layer counts as filled when it produced something. Whether the run that produced it was observed is the second number.">
+        {fill_of(paperData.slug).done}/{fill_of(paperData.slug).total} layers have output
+      </span>
+      <span class="tabular-nums" title="Runs the ledger watched, and can therefore still check against their inputs.">
+        {fill_of(paperData.slug).observed} with an observed run
+      </span>
       {reran > 0 && <span class="tabular-nums">{reran} re-run from deposited code</span>}
       <span class="tabular-nums">0 approved by a person</span>
       {(paperData as any).verificationLevel && (paperData as any).verificationLevel !== 'unknown' && (
@@ -251,10 +256,14 @@ const tabs = [
     <div class="paper-tab-panel" data-tab-id="pipeline" data-tab-active="false">
       <div class="flex items-baseline justify-between gap-3 mb-2">
         <p class="text-sm text-gray-600 dark:text-gray-400 max-w-2xl m-0">
-          The layers this paper has been through, and what each rests on.
+          The layers this paper has been through, and what each rests on. A cell is filled when
+          the layer produced something; <em>run not observed</em> means the output is there and
+          the run that made it was reconstructed rather than watched, so its inputs were never
+          hashed and nothing can say whether it is still current.
         </p>
         <span class="text-xs font-mono text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
-          {fill_of(paperData.slug).done}/{fill_of(paperData.slug).total} ·
+          {fill_of(paperData.slug).done}/{fill_of(paperData.slug).total} with output ·
+          {fill_of(paperData.slug).observed} observed ·
           <a href={`${base}/pipeline/`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">all papers</a>
         </span>
       </div>

--- a/site/src/pages/papers/index.astro
+++ b/site/src/pages/papers/index.astro
@@ -49,7 +49,8 @@ const stageLabel: Record<string, string> = {
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-8 max-w-2xl">
       Ten eLife neuroscience papers, ordered by how much of the pipeline each has been
       through. Each strip is the {rows[0]?.fill.total ?? 0} layers a paper can go through, in
-      dependency order; a filled cell has run. No paper has been approved by a person.
+      dependency order; a filled cell produced something, which is not the same as a run the
+      ledger watched. No paper has been approved by a person.
     </p>
 
     <div class="space-y-3">
@@ -76,7 +77,7 @@ const stageLabel: Record<string, string> = {
                 ))}
               </div>
               <span class="font-mono text-[11px] text-gray-500 dark:text-gray-400 tabular-nums">
-                {fill.done}/{fill.total} layers
+                {fill.done}/{fill.total} layers with output
               </span>
             </div>
 


### PR DESCRIPTION
Gädeke's pipeline tab read **18/21 layers** over fifteen cells that each said **no run recorded** — and the drawer for one of them said it directly above the artifact that run produced. Both halves were true, and the page made them look like a contradiction.

## What was actually wrong

#30 was right that a backfilled entry must stop asserting inputs it never observed. It did that by returning `{"state": "unrecorded"}` and dropping everything else the entry carries.

Thirteen of Gädeke's fifteen `unrecorded` cells have a ledger entry naming a version, a date, and — for the three readers and `edge-inference` — the model that answered:

| layer | entry | v | ran | by |
|:--|:--|:--|:--|:--|
| `results-reader` | backfilled | 1 | 2026-09-10 | `deepseek/deepseek-chat` |
| `edge-inference` | backfilled | 1 | 2026-09-10 | `claude-opus-5 (agent, not the configured backend)` |
| `caption-reader` | backfilled | 1 | 2026-09-10 | `deepseek/deepseek-chat` |
| … | | | | |
| `summaries` | none | — | — | — |
| `synthesis` | none | — | — | — |

All of it was discarded on the way to the page, so a cell with a known author and a known date rendered as though nothing had happened.

## What this changes

The inputs stay unasserted — that is the whole point of #30. What the entry *does* hold is kept: `v`, `ran`, `note`, `by`, and a `backfilled` flag. `by` is written as the literal string `"unrecorded"` when the backfill could not tell who answered, so that is dropped rather than rendered as an author named *unrecorded*.

The drawer for `results-reader` on Gädeke now reads:

```
run not observed · v1 · 2026-09-10
answered by deepseek/deepseek-chat
backfilled from runs/manifest.json
The version and the date are real; the inputs were never hashed, so nothing
can say whether this is still current.
```

**The label.** "no run recorded" overstated the gap in the other direction — a run *was* recorded, just not watched. `run not observed` names which of the two is missing, and `STATE_NOTE` already carried the sentence.

**The counter.** `fill_of` counts cells that are not `absent`, which is cells that produced something. How many runs the ledger can still *check* is a different question, and printing the first alone beside fifteen unobserved cells is what made the tab read wrong. Both numbers now appear — "19/22 layers have output · 4 with an observed run" — on the paper page, its pipeline tab, and the papers index, and the papers index no longer says "a filled cell has run".

Two cells stay bare, correctly: `summaries` and `synthesis` have an artifact on disk and no ledger entry at all.

## Checks

`make check`, `make fresh` and `npm run build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
