### PR TITLE
/docs navigates across the top, like every other section

### DIFF
--- a/site/src/components/DocsNav.astro
+++ b/site/src/components/DocsNav.astro
@@ -1,75 +1,49 @@
 ---
-// The docs sidebar — nine entries, written here because there are nine.
+// The docs tab strip — ten entries, written here because there are ten.
 //
 // This replaced a 39-item Starlight sidebar over a section describing a system that had
 // changed underneath it. The list is short enough to read, which is the point: a reader can
 // see the whole of /docs at once and tell what it does not cover.
+//
+// It is a strip rather than a sidebar because every other section of this site puts its own
+// navigation across the top — /standards has the same component one directory over — and a
+// section that navigates differently reads as a different site. Ten entries fit across a line
+// once the labels are the short names rather than the page titles; the page's own h1 carries
+// the long title, so nothing is lost by shortening them here.
 export interface Props { current: string }
 const { current } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-const GROUPS: { label: string; items: { slug: string; label: string }[] }[] = [
-  {
-    label: 'Start',
-    items: [
-      { slug: 'index', label: 'Overview' },
-      { slug: 'install', label: 'Install and configure' },
-      { slug: 'first-paper', label: 'One paper end to end' },
-    ],
-  },
-  {
-    label: 'The tools',
-    items: [
-      { slug: 'runner', label: 'The runner' },
-      { slug: 'layers', label: 'The layer runners' },
-      { slug: 'batch', label: 'Batch operation' },
-      { slug: 'evaluate', label: 'Measuring a prompt change' },
-    ],
-  },
-  {
-    label: 'Reference',
-    items: [
-      { slug: 'config', label: 'Configuration' },
-      { slug: 'prompts', label: 'The prompts' },
-      { slug: 'contributing', label: 'For contributors' },
-    ],
-  },
+// In reading order: start, then the tools, then reference.
+const PAGES: { slug: string; label: string }[] = [
+  { slug: 'index', label: 'Overview' },
+  { slug: 'install', label: 'Install' },
+  { slug: 'first-paper', label: 'First paper' },
+  { slug: 'runner', label: 'Runner' },
+  { slug: 'layers', label: 'Layers' },
+  { slug: 'batch', label: 'Batch' },
+  { slug: 'evaluate', label: 'Evaluate' },
+  { slug: 'config', label: 'Config' },
+  { slug: 'prompts', label: 'Prompts' },
+  { slug: 'contributing', label: 'Contributing' },
 ];
 
 const href = (slug: string) => `${base}/docs/${slug === 'index' ? '' : slug + '/'}`;
 ---
 
-<nav class="docs-nav text-sm" aria-label="Documentation">
-  {GROUPS.map(g => (
-    <div class="mb-5">
-      <div class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
-        {g.label}
-      </div>
-      <ul class="list-none p-0 m-0 space-y-1">
-        {g.items.map(it => (
-          <li>
-            <a href={href(it.slug)}
-               aria-current={it.slug === current ? 'page' : undefined}
-               class={`block no-underline leading-snug py-0.5 ${
-                 it.slug === current
-                   ? 'text-amber-700 dark:text-amber-400 font-medium'
-                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-               }`}>{it.label}</a>
-          </li>
-        ))}
-      </ul>
-    </div>
-  ))}
-
-  <div class="pt-4 border-t border-gray-100 dark:border-gray-800">
-    <div class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
-      Not here
-    </div>
-    <ul class="list-none p-0 m-0 space-y-1 text-gray-500 dark:text-gray-400">
-      <li><a href={`${base}/pipeline/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The layer model</a></li>
-      <li><a href={`${base}/method/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The methodology</a></li>
-      <li><a href={`${base}/pipeline/vocabulary/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">Roles and relations</a></li>
-      <li><a href={`${base}/papers/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The claim graphs</a></li>
-    </ul>
-  </div>
+<nav class="flex flex-wrap border-b-2 border-gray-200 dark:border-gray-700 mb-8" aria-label="Documentation">
+  {PAGES.map(p => {
+    const on = p.slug === current;
+    return (
+      <a href={href(p.slug)}
+         aria-current={on ? 'page' : undefined}
+         class={`font-mono text-xs tracking-wide px-3.5 py-2.5 -mb-0.5 no-underline whitespace-nowrap
+           border-b-2 transition-colors ${
+           on
+             ? 'border-amber-600 dark:border-amber-500 text-gray-900 dark:text-gray-100 font-medium'
+             : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+         }`}>{p.label}</a>
+    );
+  })}
+  <span class="flex-1 border-b-2 border-transparent"></span>
 </nav>

--- a/site/src/pages/docs/[...slug].astro
+++ b/site/src/pages/docs/[...slug].astro
@@ -41,30 +41,29 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <Layout title={title} description={description}>
-  <div class="site-frame py-10">
-    <div class="md:grid md:grid-cols-[190px_minmax(0,1fr)] md:gap-10">
+  <div class="site-frame column py-12">
 
-      <aside class="mb-8 md:mb-0">
-        <div class="md:sticky md:top-16">
-          <DocsNav current={slug} />
-        </div>
-      </aside>
+    <DocsNav current={slug} />
 
-      <article class="min-w-0">
-        <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0 mb-6">
-          {title}
-        </h1>
-        <div class="method-prose" set:html={html} />
+    <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0 mb-6">
+      {title}
+    </h1>
+    <div class="method-prose" set:html={html} />
 
-        <footer class="mt-12 pt-6 border-t border-gray-100 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400">
-          <p class="m-0">
-            This page is <code>docs/cli/{slug}.md</code> in the repository, rendered here.
-            The model these commands operate on is on
-            <a href={`${base}/pipeline/`} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">the pipeline pages</a>.
-          </p>
-        </footer>
-      </article>
+    <footer class="mt-12 pt-6 border-t border-gray-100 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400">
+      <p class="m-0 mb-4">
+        This page is <code>docs/cli/{slug}.md</code> in the repository, rendered here.
+      </p>
+      <div class="text-[10px] font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
+        Not here
+      </div>
+      <ul class="list-none p-0 m-0 flex flex-wrap gap-x-6 gap-y-1">
+        <li><a href={`${base}/pipeline/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The layer model</a></li>
+        <li><a href={`${base}/method/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The methodology</a></li>
+        <li><a href={`${base}/pipeline/vocabulary/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">Roles and relations</a></li>
+        <li><a href={`${base}/papers/`} class="no-underline hover:text-gray-900 dark:hover:text-gray-200">The claim graphs</a></li>
+      </ul>
+    </footer>
 
-    </div>
   </div>
 </Layout>


### PR DESCRIPTION
The `/docs` pages carried a 190px left sidebar — a holdover from the Starlight section they replaced — while `/standards`, `/pipeline` and the rest put their navigation in a strip above the content. A section that navigates differently reads as a different site. This is the structural half of #30's third point; the sidebar was the last piece of Starlight's shape still standing.

## What changed

`DocsNav.astro` becomes that strip, in the same idiom as `StandardsTabs.astro` one directory over: real links with their own URLs, mono labels, amber underline on the current page, same padding and type scale.

The three group headings (Start / The tools / Reference) go with the sidebar. The order still reads start, then tools, then reference, so the grouping survives as sequence. Labels shorten to the names rather than the page titles — `Layer runners` → `Layers` was the one that decided it — so all ten fit on one line of the 56rem column. Nothing is lost by shortening: each page's `h1` still carries its own full title.

The "Not here" cross-links (the layer model, the methodology, roles and relations, the claim graphs) move into the page footer, beside the line naming the markdown file the page was rendered from. That is where a reader who has finished the page is already looking.

## Verification

Checked in the dev server across `/docs/`, `/docs/runner/`, `/docs/config/` and `/docs/prompts/`: one row at desktop width with room to spare, wrapping cleanly at 375px, correct active state in both light and dark. `npm run build` completes — 573 pages, no errors.

The other items on #30 — generated corpus figures, the two meanings of *pipeline*, documenting the ledger and approval model — are untouched here and the issue should stay open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)