### PR TITLE
The exports join the build, and the gate covers them (#41)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SITE   := site
 
 .DEFAULT_GOAL := help
 
-.PHONY: help data mira-exports validate build preview check contract report fresh deps
+.PHONY: help data validate build preview check contract report fresh deps
 
 help:  ## Show this help
 	@grep -hE '^[a-z-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -37,34 +37,36 @@ $(SITE)/node_modules: $(SITE)/package-lock.json
 
 deps: $(SITE)/node_modules  ## Install the site's node modules
 
-# The generators that are safe to run on every build, in dependency order.
+# Every generator, in dependency order.
 #
-# exports/ is deliberately NOT here, and that is a known hole rather than an oversight.
-# export_mira.py stamps date.today() into every record's `created` and `modified`, so
-# regenerating changes all 30 export files on any day but the one they were last written.
-# Wiring it in would make `make fresh` fail every morning for a reason unconnected to the
-# corpus, and a gate that cries wolf daily is worse than no gate.
+# exports/ used to be excluded, because export_mira.py stamped date.today() into every
+# record's `created` and `modified` and so rewrote all 30 export files on any day but the one
+# they were last written. That defeated the thing it fed: corpus_facts hashes those files for
+# pipeline state, so running the exporter flipped every paper's mira-export cell from
+# `current` to `stale` with the three export paths under `moved`. The dates now come from the
+# claims' own `priority` fields, so the export is a function of its inputs and running it
+# twice is a no-op — which is what lets it live here instead of in a target run by hand.
 #
-# It is worse than cosmetic: corpus_facts hashes those files for pipeline state, so running
-# the exporter flips every paper's mira-export cell from `current` to `stale` with the three
-# export paths listed as `moved`. A timestamp carrying no information defeats the staleness
-# model it feeds. `make exports` runs them by hand until the exporter is deterministic.
-data: $(SITE)/node_modules  ## Regenerate the artifacts that are safe to rebuild every time
+# Order is dependency order, and four edges in it are real:
+#   prediction_outcome writes review/prediction-outcome.json, which corpus_facts reads
+#   export_mira        writes the .mira.jsonld files formats_report and validate_mira read
+#   formats_report     writes the .formats.json files corpus_facts reads
+#   validate_mira      writes site/src/data/mira-validation.json, which corpus_facts reads
+# corpus_facts therefore runs after all four, not second.
+#
+# Still NOT regenerated here: exports/{paper}.oxa.json and exports/{paper}.dg.jsonld, which
+# come from extract/scripts/migrate_to_oxa.py and export_discourse_graphs.py, run per paper.
+# formats_report reads both, so after a claim change its report is computed partly from stale
+# inputs. The pipeline state flags oxa and dg as stale, so it surfaces rather than hiding.
+data: $(SITE)/node_modules  ## Regenerate every artifact the site is built from
 	$(PYTHON) scripts/prediction_outcome.py --write
+	$(PYTHON) scripts/export_mira.py --all
+	$(PYTHON) scripts/formats_report.py --all
+	$(MAKE) validate PYTHON=$(PYTHON)
 	$(PYTHON) scripts/corpus_facts.py
 	$(PYTHON) scripts/agents_report.py
 	$(PYTHON) scripts/review_queue.py
 	cd $(SITE) && CORPUS=$(CORPUS) node scripts/build-data.js
-
-# Named for what it actually rebuilds. It does NOT regenerate exports/{paper}.oxa.json or
-# exports/{paper}.dg.jsonld — those come from extract/scripts/migrate_to_oxa.py and
-# export_discourse_graphs.py, run per paper — and formats_report reads both. So after a claim
-# change this leaves the formats report computed partly from stale inputs. The pipeline state
-# flags oxa and dg as stale, so it surfaces; calling the target `exports` implied otherwise.
-mira-exports:  ## Rebuild the MIRA exports and formats report, and validate. Not part of `data`.
-	$(PYTHON) scripts/export_mira.py --all
-	$(PYTHON) scripts/formats_report.py --all
-	$(MAKE) validate PYTHON=$(PYTHON)
 
 validate:  ## SHACL-validate the MIRA exports (needs pyshacl)
 	@command -v pyshacl >/dev/null 2>&1 || { \
@@ -112,14 +114,14 @@ preview: build  ## Build and serve locally
 # yet produces no diff at all, so a new review topic or a new export could appear, be
 # untracked, and the gate would still call the tree clean.
 #
-# The pathspec covers every directory `data` writes. site/public matters and is easy to miss:
-# build-data.js copies the exports and design notes the site serves for download, so leaving
-# it out means the published files can disagree with the exports they were copied from —
-# exactly the drift build-data.js says in its own comments that it exists to prevent.
-# exports/ is excluded because `data` does not write it — see the note above. site/public is
-# included because build-data.js copies the served exports and design notes there, and a stale
-# copy means the files the site offers for download disagree with the ones they came from.
-GENERATED := site/src/data site/public review
+# The pathspec covers every directory `data` writes. Two of them are easy to miss:
+# exports/, now that the exporter is deterministic enough to run on every build — without it,
+# editing a claim's relations leaves exports/ and everything downstream describing the old
+# claim while the gate stays green; and site/public, because build-data.js copies the exports
+# and design notes the site serves for download there, so leaving it out means the published
+# files can disagree with the exports they were copied from — exactly the drift build-data.js
+# says in its own comments that it exists to prevent.
+GENERATED := site/src/data site/public review exports
 fresh: data  ## Fail if regenerating changed anything that was committed
 	@if [ -n "$$(git status --porcelain -- $(GENERATED))" ]; then \
 	  echo ""; \
@@ -127,8 +129,6 @@ fresh: data  ## Fail if regenerating changed anything that was committed
 	  git status --porcelain -- $(GENERATED); \
 	  echo ""; \
 	  echo "Run 'make data' and commit the result."; \
-	  echo 'If corpus-facts.json flipped a cell to `stale` with export paths under'; \
-	  echo '`moved`, the cause is exports/ — run "make mira-exports" first.'; \
 	  exit 1; \
 	fi
 	@echo "Generated data matches the corpus."

--- a/site/scripts/build-data.js
+++ b/site/scripts/build-data.js
@@ -536,6 +536,20 @@ if (existsSync(exportsSrc)) {
   console.log(`Copied ${n} export files to public/exports/`);
 }
 
+// The CiTO extension vocabulary is served from /exports/ alongside them, but it is not an
+// export: it is hand-written and lives in docs/schema-mapping/. It was placed in
+// public/exports/ by hand, and the slug filter above cannot match a `.ttl` name, so nothing
+// ever copied it — leaving the one file in a directory the freshness gate covers that no
+// generator could keep true. Copied from its source so it cannot drift from what the docs
+// link to.
+const ttl = 'claim-relations.ttl';
+const ttlSrc = join(projectRoot, 'docs', 'schema-mapping', ttl);
+if (existsSync(ttlSrc)) {
+  mkdirSync(exportsDst, { recursive: true });
+  fs.copyFileSync(ttlSrc, join(exportsDst, ttl));
+  console.log(`Copied ${ttl} to public/exports/`);
+}
+
 // ── Index the artifacts the pipeline declares ──────────────────────────────
 // `produces` in layers.yaml is a repo path with {paper} unsubstituted, and the site has been
 // treating every one of them as a file that exists. It is not: of the paths this corpus

--- a/site/src/pages/standards/cito.astro
+++ b/site/src/pages/standards/cito.astro
@@ -22,7 +22,7 @@ const std = stdById['cito'];
               title={DEPTH_NOTE[std.depth]}>{std.depth}</span>
       </div>
       <p class="text-gray-600 dark:text-gray-400 m-0 leading-relaxed">The Citation Typing Ontology: forty typed relations between documents, and the standard vocabulary of the SPAR ontologies. We borrow it for relations between claims, which is outside its intended scope.</p>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 m-0"><code>docs/schema-mapping/cito-mapping.md</code> · extensions in <code>exports/claim-relations.ttl</code></p>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 m-0"><code>docs/schema-mapping/cito-mapping.md</code> · extensions in <code>docs/schema-mapping/claim-relations.ttl</code></p>
     </header>
 
     <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-5 mb-10 max-w-2xl">
@@ -74,7 +74,7 @@ const std = stdById['cito'];
 
     <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Does it validate</h2>
     <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-10 max-w-2xl">
-      Unknown. <code>exports/claim-relations.ttl</code> defines the eight extensions as OWL
+      Unknown. <code>docs/schema-mapping/claim-relations.ttl</code> defines the eight extensions as OWL
       subproperties; nothing has been run against a reasoner, and no export is checked for CiTO
       conformance. That is a gap, not a result.
     </p>


### PR DESCRIPTION
Closes #41.

## What was wrong

`make fresh` could pass while `exports/` still described a claim that had been edited since. `data` did not regenerate the exports, and `GENERATED` did not name them — both deliberate, because `export_mira.py` stamped `date.today()` into every record's `created` and `modified`, so regenerating rewrote all 30 files on any day but the one they were last written. Wiring them in would have made the gate fail every morning for a reason unconnected to the corpus.

That cause is gone. 4c2eab7 derives the dates from the claims' own `priority` fields, so the export is a function of its inputs. The exclusion outlived its reason, and this removes it.

## What changed

- `export_mira --all`, `formats_report --all` and `validate_mira` run inside `make data`; `exports/` joins the freshness pathspec. The `mira-exports` target is gone — everything it did now happens on every build.
- `corpus_facts` moves after them rather than second. It reads the `.formats.json` files and `mira-validation.json`, so running it first computed the published facts from the previous run's exports.
- `mira-validation.json` was the hole with no backstop at all: no layer declares it, so nothing hashes it, and repinning `vendor/mira.shacl` or changing the upstream/ours classification left the committed verdict and the site's "0 violations of ours" line asserting the old answer with nothing going red. It is written inside `data` now, and `site/src/data` was already in the pathspec.
- `site/public/exports/claim-relations.ttl` was placed by hand and no generator could reach it — `build-data.js` derives the slug with a regex that cannot match `.ttl`. It is now copied from `docs/schema-mapping/claim-relations.ttl`, its actual home, which is also what the CiTO page names: it cited `exports/claim-relations.ttl`, a repo path that does not exist.

## Verified

- `make fresh` green on an unmodified tree, twice — the second run under `TZ=Pacific/Kiritimati`, which makes it tomorrow. That is the two-days-running check the issue asks for, without waiting a day.
- Flipping one `supports` to `tests` in `kammer-2026-foveal-feedback` fails the gate and names the four export files plus their published copies. Before this change that edit passed.
- `validate_mira`: 165 violations across 12 papers, 165 upstream, **0 ours**.
- `make check` clean; `astro build` builds 595 pages.

## Not fixed here

`exports/{paper}.oxa.json` and `.dg.jsonld` still come from per-paper scripts outside `data`, so `formats_report` reads them as they were last written. The pipeline state flags them stale, so it surfaces rather than hiding — but the formats report is still computed partly from stale inputs after a claim change.

`mira-validation.json` is now gated but still undeclared in `pipeline/layers.yaml`, so no cell goes stale when the pinned shapes move — CI goes red instead. Declaring validation as a layer is a design decision, not a cleanup, so it is left for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)