### PR TITLE
docs(design): parts — a claim tree has two grains

### DIFF
--- a/docs/design/2026-09-11-parts.md
+++ b/docs/design/2026-09-11-parts.md
@@ -1,0 +1,115 @@
+# Parts: a claim tree has two grains
+
+**Status:** proposed
+**Issue:** [#75](https://github.com/zmainen/elife-claim-trees/issues/75)
+**Frames:** [#56](https://github.com/zmainen/elife-claim-trees/issues/56) · [#19](https://github.com/zmainen/elife-claim-trees/issues/19)
+**Depends on:** `docs/claim-format.md`, `scripts/relations.py`, the `reconcile` and `claim-tree` layers, `runs/gadeke-2026-guilt-insula/claim-tree.v1` beside `claims/gadeke-2026-guilt-insula`
+
+Gädeke's claim tree went from 33 claims to 74 when the recorded chain replaced the curated
+tree. The matcher says the new tree contains 26 of the old 27, so the growth is not loss; it is
+that the two trees are cut at different grains. This note argues that the difference is real,
+that the format should carry both grains rather than choosing one, and that one relation does
+it. It ends with the retrofit, which needs no re-run.
+
+## What the 42 extra claims are
+
+Reading each of v2's unmatched claims against the nearest v1 claim and against its own edges,
+they sort into five kinds. The counts are a first reading, to be adjudicated, not a measurement.
+
+| Kind | About | Example |
+|:--|--:|:--|
+| **Parts** — a component or refinement of a claim v1 states once | 12 | v1: the insula tracks the guilt effect. v2 also: the insula ROIs responded more to low partner outcomes in Social than Partner; the low-minus-high difference was larger in Social. |
+| **Duplicates** — the same proposition twice, which the reconciler kept apart | 5 | `both-studies-participants-felt-worse` restates `when-partner-received-low-lottery`; two claims state the insula–IFG connectivity result. |
+| **Premises** — what the argument leans on, which v1 had no node for | 10 | the three literature-context claims; the five happiness models; the model-based GLM; the parameter recovery. |
+| **New** — claims v1 did not make | 9 | the connectivity hypothesis with its prediction and two tests; the precuneus and TPJ result; the icebreaker manipulation check. |
+| **Procedure** — not claims by the contract's own rule | 6 | Z-scoring; the risk-premium definition; head-motion exclusions; the power analysis. |
+
+Two of the five are pipeline faults with known fixes: the duplicates are the reconciler applying
+"when in doubt keep them apart" to pairs that were not in doubt, and the procedure is the
+structure reader ignoring a rule the contract states without an example. The premises and the
+new claims are the chain doing what the curated tree did not. The parts are the subject of this
+note.
+
+## Why parts are not a mistake, and not claims either
+
+A part is a real proposition with its own panel, its own numbers and, often, its own
+verification record. `responsibility-model-yielded-higher-values` carries the R² comparison
+across both studies; `likelihood-ratio-test-showed-responsibility`, its parent, carries the
+model-selection verdict those R² values are one leg of. Coverage wants the part, because the
+paper states it and a tree without it has a gap. Verification wants the part, because the
+number that was recomputed lives there. A reader of the paper's argument does not want it,
+because the parent already says what it establishes.
+
+v1 solved this by folding parts into their parents at authoring time, which is why v1 is short
+and why the matcher calls it a subset. The chain solves nothing: it returns every statement at
+the grain the prose states it, which is why v2 is long. Neither is the right tree, because the
+format has no way to say that one claim is a component of another. The graph half-says it
+already — nine of the twelve parts carry a `supports` or `tests` edge into the claim they are a
+part of — but `supports` is evidence, not composition, and a filter on `supports` cannot tell a
+component from an independent finding that happens to support the same thing.
+
+## The proposal: one relation
+
+Add `part-of` to the relation vocabulary: from a component to the claim it is a component of.
+Direction: from the part to the whole. Definition: the source states one comparison, condition,
+measure or study that the target states as a whole, and the target would be weakened but not
+falsified by the source alone. It is not an opposition, so it joins the `GAPS` group in
+`scripts/relations.py` beside `requires` and `scopes`, and it gets a direction rule and a corpus
+example there like every other relation.
+
+Four things follow, each small.
+
+**The reconciler gets a third outcome.** Today a candidate pair is *the same claim* (merge) or
+*different claims* (keep both), and the prompt says to prefer the second when torn. A pair can
+now be *one a part of the other*: keep both and write `part-of`. That is where most of the
+duplicates go too, because a restatement across two studies is a part of the claim that
+covers both. The rule in the task file is one paragraph, and the confusable-pair example in the
+contract is the insula ROI result beside the voxel-wise result.
+
+**The writer and the numbering nest parts.** The site already hangs predictions off hypotheses
+and tests off predictions (`H1.P2.E1`). A part hangs off its whole with a letter, `E3.a`, and
+the paper page shows wholes by default with parts folded beneath them. Corpus totals report
+wholes and parts separately: "31 claims, 12 parts" is honest where "43 claims" is not.
+
+**Coverage and verification change nothing.** Both already read every claim file. A part is a
+claim file. The spans a part accounts for stay accounted for, and a reproduction record on a
+part stays on the part, where the number is.
+
+**Exports carry it where they can.** MIRA has no predicate for composition; `part-of` goes in
+the `haak:` namespace of the extended file and the gap report says so, like `entails` does
+today. OXA is document-shaped and can nest a part inside its whole directly. Discourse Graphs
+has no node for it and drops it, which the formats report will measure.
+
+## The retrofit
+
+This lands the way `stance` and `questions` did: a feature layer, `parts`, paper-scope, needing
+`claim-tree`, with a dump-and-answer prompt. Given a tree's claims with their edges, it returns
+the `part-of` edges it finds and writes them into the claim files. It reads the tree, not the
+paper, so it is cheap; it is recorded and approvable like any layer; and no reader re-runs.
+On Gädeke v2 the first reading above predicts roughly a dozen edges and a page that shows about
+thirty claims, which is what v1 had, with the premises and the new arc that v1 lacked.
+
+The reconciler change is separate and takes effect on the next induction. Between the two, a
+tree induced under the old reconciler and retrofitted by `parts` and one induced under the new
+reconciler should agree, which is a test the sweep in item 7 can run.
+
+## What this does not decide
+
+Whether a part may have parts. The Gädeke reading found none two levels deep, and the numbering
+scheme would allow it; leaving it unconstrained costs nothing until a paper needs it.
+
+Whether the six procedure claims are wrong or are parts of scope claims. Three of them
+(head-motion exclusions, the power analysis, the two-study design) read as components of the
+paper's scope claim rather than as non-claims, which would make them parts too. That is the
+kind of line the adjudication draws better than a prompt does.
+
+Whether the corpus's claim count should be wholes only. The site's figures are generated, so
+the choice is one token in `corpus_facts.py`; the note recommends reporting both and leading
+with wholes.
+
+## Cost
+
+Vocabulary, contract and confusable example: half a day. The `parts` layer with prompt, runner
+and tests: one day. Writer, numbering and paper page: one day. Reconciler paragraph: an hour.
+The retrofit on Gädeke, answered by a subagent and recorded: an hour. Roughly three days, and
+the first two are independent of the third.


### PR DESCRIPTION
Design note for #75, proposed and not implemented. Adds `docs/design/2026-09-11-parts.md`.

**The finding.** Gädeke's claim tree went from 33 to 74 claims when the recorded chain replaced the curated tree (#73), holding 26 of the old 27. Read one by one, the 42 extras are parts of claims v1 states once (~12), duplicates the reconciler kept apart (~5), premises v1 had no node for (~10), claims v1 did not make (~9), and procedure that should not be claims (~6).

**The proposal.** One relation, `part-of`, from a component to its whole. The reconciler gets a third outcome for a candidate pair; the writer and the site nest parts under wholes and show wholes by default; corpus totals report both grains; coverage and verification change nothing, because a part is a claim file with its own panel and its own verification record. It lands as a `parts` feature layer that reads a tree and writes the edges, recorded and approvable, no re-run.

Frames #56 and #19. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)