### PR TITLE
chore(check): the gate imports the package and runs its tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ validate:  ## SHACL-validate the MIRA exports (needs pyshacl)
 check:  ## Gates that are clean on main. A failure here is this change's fault.
 	$(PYTHON) scripts/check_relations.py
 	cd extract && $(PYTHON) -m elife_extract.cli contract
+	# PR #95 deleted a name from edges.py and left a reference — the package failed to import
+	# on main while `make check` stayed green because contract reaches it through deferred paths.
+	cd extract && $(PYTHON) -c "import elife_extract.cli, elife_extract.edges, elife_extract.layers, elife_extract.write"
+	cd extract && $(PYTHON) tests/test_layer_contract.py
+	cd extract && $(PYTHON) tests/test_prompt_contract.py
 	$(PYTHON) scripts/audit_layers.py
 
 contract:  ## Regenerate the prompt contract from vocabulary.py, relations.py and schema.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,11 @@ pydantic>=2.0
 # SHACL validation of the MIRA exports (scripts/validate_mira.py shells out to `pyshacl`).
 # Kept here rather than installed ad hoc in the workflow so there is one list to read.
 pyshacl>=0.25
+
+# `make check` now imports elife_extract.edges, .layers, and .write directly. Those modules
+# pull in anthropic, httpx, lxml, and oxa-types at module level, so CI needs them installed.
+# Versions match extract/pyproject.toml; oxa-types is on PyPI.
+anthropic[vertex]>=0.40
+httpx>=0.25
+lxml>=4.9
+oxa-types>=0.1


### PR DESCRIPTION
PR #95 deleted a name in `edges.py` and left a reference — the package failed to import on main and both test files went red, but `make check` stayed green. The contract subcommand reaches the package through deferred imports that never touch `edges.py`, so the gate was blind to the breakage.

## What changed

**`Makefile` — `check` target:** three additions after `check_relations.py` and the contract check:
- an import smoke test (`python3 -c "import elife_extract.cli, elife_extract.edges, elife_extract.layers, elife_extract.write"`) run from `extract/`, so a bad reference fails before any test runs
- `python3 tests/test_layer_contract.py` — the layer runner contract suite (standalone `__main__` runner, no pytest dependency)
- `python3 tests/test_prompt_contract.py` — the prompt contract suite (same)

**`requirements.txt`:** added four packages that `elife_extract` imports at module level and that CI's `pip install -r requirements.txt` did not provide: `anthropic[vertex]`, `httpx`, `lxml`, `oxa-types`. Versions match `extract/pyproject.toml`.

## Verification

`make check` passes (42/42 layer tests, 14/14 prompt tests). Temporarily breaking `edges.py` with a bad attribute name caused `make check` to fail at the smoke test with an `AttributeError` — the way it should have on #95. Reverted. `make fresh` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)