### PR TITLE
feat(pipeline): structured outputs, budgets, parallel readers, cached prompts with usage recorded, and review as a patch

### DIFF
--- a/extract/elife_extract/agents.py
+++ b/extract/elife_extract/agents.py
@@ -392,6 +392,38 @@ def reset_client():
     _client_cache = None
 
 
+# Labels that warrant high inference effort (complex synthesis or graph tasks).
+_HIGH_EFFORT_LABELS: frozenset[str] = frozenset(
+    {"reconciler", "external-reviewer", "parts"}
+)
+
+
+def _effort_for(label: str | None) -> str:
+    """Map a call label to an effort level for output_config.
+
+    High: reconciler, external-reviewer, edge-inference*, parts.
+    Medium: readers and everything else.
+    """
+    if label and (label in _HIGH_EFFORT_LABELS or label.startswith("edge-inference")):
+        return "high"
+    return "medium"
+
+
+def _supports_adaptive_thinking(model: str) -> bool:
+    """True for Claude 4.6+ and 5+ models that use thinking: {type: adaptive}.
+
+    budget_tokens is rejected with HTTP 400 on these models; adaptive is the
+    correct form. Pre-4.6 models still use budget_tokens.
+    """
+    import re
+    m = re.search(r"(\d+)-(\d+)", model)
+    if m:
+        return (int(m.group(1)), int(m.group(2))) >= (4, 6)
+    # bare major version, e.g. "claude-opus-5"
+    m = re.search(r"-(\d+)$", model)
+    return bool(m and int(m.group(1)) >= 5)
+
+
 def stream_text(
     cfg: Config,
     *,
@@ -401,13 +433,16 @@ def stream_text(
     max_tokens: int = 32768,
     label: str | None = None,
     output_schema: dict | None = None,
-) -> str:
-    """One model call on whichever backend is configured; returns the text.
+) -> tuple[str, dict]:
+    """One model call on whichever backend is configured; returns (text, usage).
 
     When `output_schema` is given the provider enforces the reply is valid JSON
     matching that schema (Anthropic: output_config.format; litellm: response_format).
     Without it the free-text salvage parser in parse_json_response handles fences
-    and bracket mismatches. The log line names which path each reply takes.
+    and bracket mismatches. The log line names which path each reply took.
+
+    The second return value is a usage dict with keys input_tokens, output_tokens,
+    cache_read_input_tokens, cache_creation_input_tokens (all int, zero when unknown).
 
     Every model call in the package goes through here, so adding a provider
     is a config entry rather than a new code path. "vertex" and "anthropic"
@@ -418,31 +453,56 @@ def stream_text(
     tag = label or model
     chunks: list[str] = []
     progress = _Progress(tag, t0)
+    usage: dict = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
 
     if cfg.backend in ("vertex", "anthropic"):
         client = get_client(cfg)
+        # Prompt caching: wrap the system prompt in a content block so the provider
+        # can cache it across calls with the same system prompt.
+        system_blocks = [{"type": "text", "text": system,
+                          "cache_control": {"type": "ephemeral"}}]
         stream_kwargs: dict = dict(
             model=model,
             max_tokens=max_tokens,
-            system=system,
+            system=system_blocks,
             messages=[{"role": "user", "content": user}],
         )
+        # Adaptive thinking for 4.6+ models. budget_tokens is rejected on these.
+        if _supports_adaptive_thinking(model):
+            stream_kwargs["thinking"] = {"type": "adaptive"}
+        # Effort and structured output live in output_config.
+        out_cfg: dict = {"effort": _effort_for(label)}
         if output_schema is not None:
-            stream_kwargs["output_config"] = {
-                "format": {
-                    "type": "json",
-                    "json_schema": {"name": label or "output", "schema": output_schema},
-                }
+            out_cfg["format"] = {
+                "type": "json",
+                "json_schema": {"name": label or "output", "schema": output_schema},
             }
             logger.info("  %s: sending %dc to %s (%s), structured output active",
                         tag, len(system) + len(user), model, cfg.backend)
         else:
             logger.info("  %s: sending %dc to %s (%s), free-text (salvage parser active)",
                         tag, len(system) + len(user), model, cfg.backend)
+        stream_kwargs["output_config"] = out_cfg
         with client.messages.stream(**stream_kwargs) as stream:
             for text in stream.text_stream:
                 chunks.append(text)
                 progress.tick(len(text))
+            final = stream.get_final_message()
+        u = final.usage
+        usage = {
+            "input_tokens": getattr(u, "input_tokens", 0) or 0,
+            "output_tokens": getattr(u, "output_tokens", 0) or 0,
+            "cache_read_input_tokens": getattr(u, "cache_read_input_tokens", 0) or 0,
+            "cache_creation_input_tokens": getattr(u, "cache_creation_input_tokens", 0) or 0,
+        }
+        logger.info("  %s: usage in=%d out=%d cache_read=%d cache_create=%d",
+                    tag, usage["input_tokens"], usage["output_tokens"],
+                    usage["cache_read_input_tokens"], usage["cache_creation_input_tokens"])
     else:
         import litellm
 
@@ -481,14 +541,18 @@ def stream_text(
             kwargs["vertex_location"] = cfg.vertex_region
         elif cfg.api_key:
             kwargs["api_key"] = cfg.api_key
+        last_chunk_usage = None
         for chunk in litellm.completion(**kwargs):
             try:
                 delta = chunk.choices[0].delta.content
             except (AttributeError, IndexError):
-                continue
+                delta = None
             if delta:
                 chunks.append(delta)
                 progress.tick(len(delta))
+            # Some providers include usage in the final streaming chunk.
+            if getattr(chunk, "usage", None):
+                last_chunk_usage = chunk.usage
 
         # Not every provider honours stream=True for every model. Rather than
         # return an empty string and fail later in JSON parsing, retry once
@@ -499,10 +563,20 @@ def stream_text(
             kwargs["stream"] = False
             resp = litellm.completion(**kwargs)
             chunks.append(resp.choices[0].message.content or "")
+            if getattr(resp, "usage", None):
+                last_chunk_usage = resp.usage
+
+        if last_chunk_usage is not None:
+            usage = {
+                "input_tokens": getattr(last_chunk_usage, "prompt_tokens", 0) or 0,
+                "output_tokens": getattr(last_chunk_usage, "completion_tokens", 0) or 0,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
 
     raw = "".join(chunks)
     progress.done(len(raw))
-    return raw
+    return raw, usage
 
 
 class _Progress:
@@ -602,10 +676,10 @@ def run_agent(
     cfg: Config,
     *,
     max_retries: int = 2,
-) -> AgentExtraction:
+) -> tuple[AgentExtraction, dict]:
     """Run one extraction agent against the paper's slice for that role.
 
-    Returns the validated AgentExtraction. Raises on unrecoverable error.
+    Returns (AgentExtraction, usage_dict). Raises on unrecoverable error.
     Retries with exponential backoff on rate limits (429).
     """
     model = model_for(agent, cfg)
@@ -619,17 +693,18 @@ def run_agent(
         )
         return AgentExtraction(
             agent=agent, paper_slug=paper.paper_slug, model=model, claims=[]
-        )
+        ), {}
 
     schema = _reader_output_schema()
     raw = None
+    usage: dict = {}
     for attempt in range(max_retries + 1):
         try:
             logger.info("agent=%s model=%s slice=%dc (streaming)", agent, model, len(paper_slice))
             # Streaming is required by the SDK for max_tokens that may run
             # >10 minutes; we use it unconditionally for safety. The result
             # is identical to a non-streaming call once collected.
-            raw = stream_text(
+            raw, usage = stream_text(
                 cfg,
                 model=model,
                 system=system_prompt,
@@ -650,7 +725,7 @@ def run_agent(
 
     assert raw is not None
     try:
-        return reader_from_raw(agent, paper.paper_slug, model, raw, paper)
+        return reader_from_raw(agent, paper.paper_slug, model, raw, paper), usage
     except Exception as parse_err:
         # Keep the raw reply before re-raising: a reply that failed to parse is the only
         # evidence of what went wrong, and it is gone the moment this returns.

--- a/extract/elife_extract/agents.py
+++ b/extract/elife_extract/agents.py
@@ -26,6 +26,7 @@ them concurrently when cost/latency budgets demand it.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import re
@@ -42,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 # ── Evidence verification ────────────────────────────────────────────────
 
-_CURLY_QUOTES = str.maketrans({"‘": "'", "’": "'", "“": '"', "”": '"'})
+_CURLY_QUOTES = str.maketrans({"'": "‘", "’": "'", "“": '"', "”": '"'})
 _DASHES = str.maketrans({"–": "-", "—": "-", "―": "-"})
 
 
@@ -181,6 +182,10 @@ _JSON_FENCE_CLOSE = re.compile(r"\n?```\s*$")
 def parse_json_response(raw: str) -> list[dict] | dict:
     """Parse a JSON response from the model, tolerating markdown fences.
 
+    Used for --answer (free text) paths and as a fallback when structured output
+    is unavailable or returns unexpected content. The structured output path
+    bypasses the need for the salvage logic because the provider enforces valid JSON.
+
     Models sometimes wrap JSON output in ```json ... ``` despite explicit
     instructions not to. Strip leading and trailing fences independently
     (some models close with ``` while others get truncated before they
@@ -284,6 +289,85 @@ def _as_claim_list(parsed, agent: str) -> list:
     )
 
 
+# ── Schema helpers for provider-enforced structured outputs ─────────────
+
+
+def _filter_schema(schema: dict) -> dict:
+    """Remove 'Filled by the runner' fields from a JSON schema (root + all $defs).
+
+    The provider enforces the schema the model sees; fields the runner fills must
+    not appear in it, or the model will invent values for them that the runner
+    then overwrites anyway.
+    """
+    schema = copy.deepcopy(schema)
+    for container in [schema] + list(schema.get("$defs", {}).values()):
+        bad = {k for k, v in container.get("properties", {}).items()
+               if isinstance(v, dict) and v.get("description", "").startswith("Filled by the runner")}
+        if bad:
+            for k in bad:
+                container.get("properties", {}).pop(k, None)
+            if "required" in container:
+                container["required"] = [r for r in container["required"] if r not in bad]
+    return schema
+
+
+def _reader_output_schema() -> dict:
+    """JSON schema for a reader agent's output: {claims: [CandidateClaim, ...]}.
+
+    The object wrapper is required because most structured-output providers
+    (Anthropic, OpenAI) expect a top-level object. _as_claim_list already
+    handles the 'claims' key unwrap, so the rest of the parse path is unchanged.
+    """
+    claim_schema = _filter_schema(CandidateClaim.model_json_schema())
+    defs = claim_schema.pop("$defs", {})
+    claim_schema.pop("title", None)
+    result: dict = {
+        "type": "object",
+        "properties": {"claims": {"type": "array", "items": claim_schema}},
+        "required": ["claims"],
+    }
+    if defs:
+        result["$defs"] = defs
+    return result
+
+
+def _draft_table_schema() -> dict:
+    """JSON schema for the reconciler/reviewer output: filtered DraftClaimTable."""
+    from .schema import DraftClaimTable
+    return _filter_schema(DraftClaimTable.model_json_schema())
+
+
+def _edge_output_schema() -> dict:
+    """JSON schema for the edge-inference output: {edges: [{source, target, relation, why}]}.
+
+    _parse_edges already extracts the inner array from an object wrapper by locating the first
+    '[' and the last ']', so this wrapper does not require changes to the parsing path.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "edges": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "source": {"type": "string",
+                                   "description": "The source claim's 1-based index number."},
+                        "target": {"type": "string",
+                                   "description": "The target claim's 1-based index number."},
+                        "relation": {"type": "string",
+                                     "description": "The relation name from the vocabulary."},
+                        "why": {"type": "string",
+                                "description": "One sentence explaining the edge."},
+                    },
+                    "required": ["source", "target", "relation", "why"],
+                },
+            }
+        },
+        "required": ["edges"],
+    }
+
+
 # ── Anthropic client (cached per session) ───────────────────────────────
 
 
@@ -316,8 +400,14 @@ def stream_text(
     user: str,
     max_tokens: int = 32768,
     label: str | None = None,
+    output_schema: dict | None = None,
 ) -> str:
     """One model call on whichever backend is configured; returns the text.
+
+    When `output_schema` is given the provider enforces the reply is valid JSON
+    matching that schema (Anthropic: output_config.format; litellm: response_format).
+    Without it the free-text salvage parser in parse_json_response handles fences
+    and bracket mismatches. The log line names which path each reply takes.
 
     Every model call in the package goes through here, so adding a provider
     is a config entry rather than a new code path. "vertex" and "anthropic"
@@ -331,12 +421,25 @@ def stream_text(
 
     if cfg.backend in ("vertex", "anthropic"):
         client = get_client(cfg)
-        with client.messages.stream(
+        stream_kwargs: dict = dict(
             model=model,
             max_tokens=max_tokens,
             system=system,
             messages=[{"role": "user", "content": user}],
-        ) as stream:
+        )
+        if output_schema is not None:
+            stream_kwargs["output_config"] = {
+                "format": {
+                    "type": "json",
+                    "json_schema": {"name": label or "output", "schema": output_schema},
+                }
+            }
+            logger.info("  %s: sending %dc to %s (%s), structured output active",
+                        tag, len(system) + len(user), model, cfg.backend)
+        else:
+            logger.info("  %s: sending %dc to %s (%s), free-text (salvage parser active)",
+                        tag, len(system) + len(user), model, cfg.backend)
+        with client.messages.stream(**stream_kwargs) as stream:
             for text in stream.text_stream:
                 chunks.append(text)
                 progress.tick(len(text))
@@ -356,14 +459,28 @@ def stream_text(
             "max_tokens": max_tokens,
             "stream": True,
         }
+        if output_schema is not None:
+            # json_schema is supported by OpenAI-compatible and Gemini backends.
+            # Providers that don't support it fall back to json_object (best effort).
+            kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": label or "output",
+                    "schema": output_schema,
+                    "strict": True,
+                },
+            }
+            logger.info("  %s: sending %dc to %s (%s), structured output active",
+                        tag, len(system) + len(user), kwargs["model"], cfg.backend)
+        else:
+            logger.info("  %s: sending %dc to %s (%s), free-text (salvage parser active)",
+                        tag, len(system) + len(user), kwargs["model"], cfg.backend)
         if cfg.backend == "vertex_ai":
             # Gemini on Vertex AI: credentials from environment, project/location explicit.
             kwargs["vertex_project"] = cfg.vertex_project
             kwargs["vertex_location"] = cfg.vertex_region
         elif cfg.api_key:
             kwargs["api_key"] = cfg.api_key
-        logger.info("  %s: sending %dc to %s (%s), awaiting first byte…",
-                    tag, len(system) + len(user), kwargs["model"], cfg.backend)
         for chunk in litellm.completion(**kwargs):
             try:
                 delta = chunk.choices[0].delta.content
@@ -504,6 +621,7 @@ def run_agent(
             agent=agent, paper_slug=paper.paper_slug, model=model, claims=[]
         )
 
+    schema = _reader_output_schema()
     raw = None
     for attempt in range(max_retries + 1):
         try:
@@ -519,6 +637,7 @@ def run_agent(
                 max_tokens=32768,  # 30+ claims with verbatim quotes routinely
                                    # exceed 10k tokens; budget for headroom
                 label=f"{agent}-reader",
+                output_schema=schema,
             )
             break
         except Exception as e:

--- a/extract/elife_extract/agents.py
+++ b/extract/elife_extract/agents.py
@@ -34,7 +34,7 @@ import time
 
 from anthropic import Anthropic, AnthropicVertex
 
-from .config import Config, LITELLM_PREFIX
+from .config import Config, LITELLM_PREFIX, token_budget
 from .prepare import PreparedPaper
 from .schema import AgentExtraction, AgentName, CandidateClaim
 
@@ -634,8 +634,7 @@ def run_agent(
                 model=model,
                 system=system_prompt,
                 user=paper_slice,
-                max_tokens=32768,  # 30+ claims with verbatim quotes routinely
-                                   # exceed 10k tokens; budget for headroom
+                max_tokens=token_budget("reader", cfg.max_claims or 30),
                 label=f"{agent}-reader",
                 output_schema=schema,
             )

--- a/extract/elife_extract/config.py
+++ b/extract/elife_extract/config.py
@@ -40,6 +40,49 @@ DEFAULT_PROMPT_VARIANT = "default"
 
 DEFAULT_BACKEND = "vertex"
 
+# ── Per-layer output-token budgets ──────────────────────────────────────
+# Budget = tokens_per_claim * n_claims, clamped to [min_tokens, max_tokens].
+# Fixed-budget layers use tokens_per_claim = 0 and return max_tokens directly.
+#
+# Rationale for each row:
+#   reader           450 t/claim — verbatim evidence quotes are long
+#   reconciler       900 t/claim — richer format: sources, evidence_by_agent, span_by_agent
+#   external-reviewer 900 t/claim — same format as reconciler (revises the draft in place)
+#   edge-inference    60 t/claim — each edge is a short 4-field object
+#   questions/parts/summaries/synthesis/abstract-map — prose outputs; small fixed ceiling
+#   stance            fixed 4096 — a small set of ruled-out alternative claims
+
+_BUDGET_TABLE: dict[str, tuple[int, int, int]] = {
+    # (tokens_per_claim, min_tokens, max_tokens)
+    "reader":             (450,     8_192, 32_768),
+    "reconciler":         (900,     8_192, 32_768),
+    "external-reviewer":  (900,     8_192, 32_768),
+    "edge-inference":     ( 60,     4_096, 32_768),
+    "questions":          (  0,       512,  2_048),
+    "parts":              (  0,       512,  2_048),
+    "summaries":          (  0,       512,  4_096),
+    "synthesis":          (  0,       512,  4_096),
+    "abstract-map":       (  0,       512,  2_048),
+    "stance":             (  0,     1_024,  4_096),
+}
+
+
+def token_budget(label: str, n_claims: int = 25) -> int:
+    """Return a max_tokens budget for *label* scaled to *n_claims*.
+
+    For layers whose budget scales with output size, *n_claims* should be the
+    expected number of output claims (reader) or the input draft's claim count
+    (reconciler/reviewer/edges).  Fixed-budget layers ignore *n_claims*.
+
+    The result is always within the [min_tokens, max_tokens] interval declared
+    in _BUDGET_TABLE, which prevents both reservation errors (HTTP 402 when the
+    provider reserves more than the account balance) and truncated output.
+    """
+    per, lo, hi = _BUDGET_TABLE.get(label, (450, 8_192, 32_768))
+    raw = per * max(n_claims, 1) if per else hi
+    return max(lo, min(hi, raw))
+
+
 LITELLM_PREFIX = {
     "openrouter": "openrouter",
     "openai": "openai",

--- a/extract/elife_extract/contract.py
+++ b/extract/elife_extract/contract.py
@@ -30,7 +30,7 @@ import yaml
 from . import schema, vocabulary
 
 CONTRACT_DIR = "contract"
-FILES = ("vocabulary.md", "schema-candidate.md", "schema-draft.md")
+FILES = ("vocabulary.md", "schema-candidate.md", "schema-draft.md", "schema-review-patch.md")
 
 
 # ── sources ──────────────────────────────────────────────────────────────
@@ -308,10 +308,53 @@ def render_schema_draft() -> str:
     return "\n".join(out)
 
 
+def render_schema_review_patch() -> str:
+    out = ["# What the external reviewer returns", "",
+           "Generated from `extract/elife_extract/schema.py` by `elife-extract contract --write`. "
+           "Do not edit.", "",
+           "A single JSON object with two keys — `edits` and `additions` — and nothing else: "
+           "no prose before or after, no code fence.", "",
+           "Top level:", ""]
+    out += _table(schema.ReviewPatch)
+    out += ["", "Each element of `edits` (targeted changes to existing claims):", ""]
+    out += _table(schema.ReviewEdit)
+    out += ["", "Each element of `additions` (new claims appended to the draft):", ""]
+    out += _table(schema.ReconciledClaim)
+    out += ["", "```json", json.dumps({
+        "edits": [
+            {
+                "claim": "Doubling distal dendritic inhibition reduces somatic firing from approximately "
+                         "5.5 Hz to approximately 0.2 Hz.",
+                "role": "empirical",
+                "notes": "[reviewer] role: empirical → control. This result rules out that somatic "
+                         "firing is driven by distal input rather than proximal.",
+            }
+        ],
+        "additions": [
+            {
+                "claim": "Distal inhibition more strongly reduces somatic firing than proximal inhibition.",
+                "panel": None,
+                "claim_type": "synthesis",
+                "role": "synthesis",
+                "addresses": None,
+                "confidence": "single-source",
+                "sources": ["reviewer"],
+                "evidence_by_agent": {
+                    "reviewer": "The contrast across fig4a (distal) and fig4b (proximal) is stated in "
+                                "the Discussion: distal inhibition is uniquely effective.",
+                },
+                "notes": "[reviewer] added: synthesis across panels.",
+            }
+        ],
+    }, indent=2), "```", ""]
+    return "\n".join(out)
+
+
 RENDER = {
     "vocabulary.md": render_vocabulary,
     "schema-candidate.md": lambda root=None: render_schema_candidate(),
     "schema-draft.md": lambda root=None: render_schema_draft(),
+    "schema-review-patch.md": lambda root=None: render_schema_review_patch(),
 }
 
 

--- a/extract/elife_extract/edges.py
+++ b/extract/elife_extract/edges.py
@@ -50,7 +50,7 @@ import logging
 import re
 from pathlib import Path
 
-from .agents import stream_text
+from .agents import _edge_output_schema, stream_text
 from .config import Config
 from .schema import DraftClaimTable, ReconciledClaim
 
@@ -373,17 +373,19 @@ def infer_edges(draft: DraftClaimTable, slugs: list[str], cfg: Config, *,
     # died on a live Gädeke run — HTTP 402 — and lost the spine while every other stage succeeded.
     budget = max(8192, min(32768, 500 * max(len(slugs), 1)))
 
+    edge_schema = _edge_output_schema()
     if per_arc:
         raws: list[str] = []
         for members in arcs(draft.claims):
             system, user = build_edge_request(draft, slugs, cfg, include=set(members))
             raws.append(stream_text(cfg, model=cfg.model_reconcile, system=system, user=user,
-                                    max_tokens=budget, label="edge-inference[arc]"))
+                                    max_tokens=budget, label="edge-inference[arc]",
+                                    output_schema=edge_schema))
         return edges_from_raw("\n".join(raws), draft.claims, slugs, source="model:per-arc")
 
     system, user = build_edge_request(draft, slugs, cfg)
     raw = stream_text(cfg, model=cfg.model_reconcile, system=system, user=user,
-                      max_tokens=budget, label="edge-inference")
+                      max_tokens=budget, label="edge-inference", output_schema=edge_schema)
     return edges_from_raw(raw, draft.claims, slugs, source="model")
 
 

--- a/extract/elife_extract/edges.py
+++ b/extract/elife_extract/edges.py
@@ -359,11 +359,12 @@ def edges_from_raw(raw: str, claims: list, slugs: list[str], *,
 
 
 def infer_edges(draft: DraftClaimTable, slugs: list[str], cfg: Config, *,
-                per_arc: bool = False) -> list[dict]:
+                per_arc: bool = False) -> tuple[list[dict], dict]:
     """Ask the configured backend for typed relations between the claims.
 
-    `per_arc` splits the work into one call per hypothesis arc and merges the replies through
-    the same validation — the merge is concatenation before validation, which de-duplicates.
+    Returns (edges, usage_dict). `per_arc` splits the work into one call per hypothesis arc
+    and merges the replies — the merge is concatenation before validation, which de-duplicates.
+    Usage is accumulated across all arc calls.
     """
     # Budget the call to what the output can actually be. An edge is a small JSON object — two
     # claim numbers, a relation name and a one-sentence why, ~80 tokens — and a paper has at most
@@ -374,17 +375,24 @@ def infer_edges(draft: DraftClaimTable, slugs: list[str], cfg: Config, *,
     edge_schema = _edge_output_schema()
     if per_arc:
         raws: list[str] = []
+        combined_usage: dict = {
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+        }
         for members in arcs(draft.claims):
             system, user = build_edge_request(draft, slugs, cfg, include=set(members))
-            raws.append(stream_text(cfg, model=cfg.model_reconcile, system=system, user=user,
-                                    max_tokens=budget, label="edge-inference[arc]",
-                                    output_schema=edge_schema))
-        return edges_from_raw("\n".join(raws), draft.claims, slugs, source="model:per-arc")
+            arc_raw, arc_usage = stream_text(
+                cfg, model=cfg.model_reconcile, system=system, user=user,
+                max_tokens=budget, label="edge-inference[arc]", output_schema=edge_schema)
+            raws.append(arc_raw)
+            for k in combined_usage:
+                combined_usage[k] += arc_usage.get(k, 0)
+        return edges_from_raw("\n".join(raws), draft.claims, slugs, source="model:per-arc"), combined_usage
 
     system, user = build_edge_request(draft, slugs, cfg)
-    raw = stream_text(cfg, model=cfg.model_reconcile, system=system, user=user,
-                      max_tokens=budget, label="edge-inference", output_schema=edge_schema)
-    return edges_from_raw(raw, draft.claims, slugs, source="model")
+    raw, usage = stream_text(cfg, model=cfg.model_reconcile, system=system, user=user,
+                             max_tokens=budget, label="edge-inference", output_schema=edge_schema)
+    return edges_from_raw(raw, draft.claims, slugs, source="model"), usage
 
 
 def _validate_edges(parsed: list, claims: list, slugs: list[str], *, source: str) -> list[dict]:

--- a/extract/elife_extract/edges.py
+++ b/extract/elife_extract/edges.py
@@ -51,7 +51,7 @@ import re
 from pathlib import Path
 
 from .agents import _edge_output_schema, stream_text
-from .config import Config
+from .config import Config, token_budget
 from .schema import DraftClaimTable, ReconciledClaim
 
 logger = logging.getLogger(__name__)
@@ -367,11 +367,9 @@ def infer_edges(draft: DraftClaimTable, slugs: list[str], cfg: Config, *,
     """
     # Budget the call to what the output can actually be. An edge is a small JSON object — two
     # claim numbers, a relation name and a one-sentence why, ~80 tokens — and a paper has at most
-    # a few edges per claim. Taking the package default of 32768 asks for far more than this call
-    # can emit, which buys nothing and costs real failures: providers that reserve the requested
-    # budget against a credit balance reject the request outright. That is how edge inference once
-    # died on a live Gädeke run — HTTP 402 — and lost the spine while every other stage succeeded.
-    budget = max(8192, min(32768, 500 * max(len(slugs), 1)))
+    # a few edges per claim. token_budget("edge-inference") scales at 60 t/claim and is clamped
+    # to [4096, 32768], preventing the HTTP 402 reservation failures that killed a live Gädeke run.
+    budget = token_budget("edge-inference", len(slugs))
 
     edge_schema = _edge_output_schema()
     if per_arc:

--- a/extract/elife_extract/external_review.py
+++ b/extract/elife_extract/external_review.py
@@ -128,7 +128,7 @@ def external_review(
     paper: PreparedPaper,
     draft: DraftClaimTable,
     cfg: Config,
-) -> DraftClaimTable:
+) -> tuple[DraftClaimTable, dict]:
     """Run the external Opus reviewer pass on a reconciled draft.
 
     Returns a revised DraftClaimTable. Preserves the original draft on
@@ -141,7 +141,7 @@ def external_review(
         "external review: paper=%s claims=%d via %s",
         paper.paper_slug, len(draft.claims), cfg.model_reconcile,
     )
-    raw = stream_text(
+    raw, usage = stream_text(
         cfg,
         model=cfg.model_reconcile,  # same model class as reconciliation
         system=system_prompt,
@@ -151,4 +151,4 @@ def external_review(
         output_schema=_draft_table_schema(),
     )
 
-    return review_from_raw(raw, draft)
+    return review_from_raw(raw, draft), usage

--- a/extract/elife_extract/external_review.py
+++ b/extract/elife_extract/external_review.py
@@ -23,7 +23,7 @@ import json
 import logging
 
 from .agents import _draft_table_schema, parse_json_response, stream_text
-from .config import Config
+from .config import Config, token_budget
 from .prepare import PreparedPaper
 from .schema import DraftClaimTable
 
@@ -146,7 +146,7 @@ def external_review(
         model=cfg.model_reconcile,  # same model class as reconciliation
         system=system_prompt,
         user=user_message,
-        max_tokens=32768,
+        max_tokens=token_budget("external-reviewer", len(draft.claims)),
         label="external-reviewer",
         output_schema=_draft_table_schema(),
     )

--- a/extract/elife_extract/external_review.py
+++ b/extract/elife_extract/external_review.py
@@ -1,17 +1,17 @@
 """External review pass — Step 4.5, between reconciliation and write.
 
 A single Opus call that takes the reconciled draft and the paper's context,
-and returns a revised draft addressing the structural-inference biases the
-three Sonnet extraction agents systematically miss:
+and returns a *patch* — targeted edits and new claims — that the runner applies
+to produce the revised draft.
 
   Bias 1: prediction-role under-coverage
   Bias 2: hypothesis-role under-coverage
   Bias 3: multi-panel claims collapsed
   Bias 4: synthesis vs interpretation confusion
 
-Substitutes for the human analyst at Step 5 when `--review-mode=external`
-is set. The methodology was written assuming a curator-in-the-loop; this
-module is what makes the CLI usable in environments without one.
+The patch format (edits + additions) is cheaper to emit and easier to audit
+than a full replacement table: the reviewer names each change explicitly, so
+a diff between the reconciled draft and the reviewed draft is meaningful.
 
 Cost: ~$1-2 per paper (one Opus call with paper context + draft).
 Latency: 1-2 minutes.
@@ -19,13 +19,13 @@ Latency: 1-2 minutes.
 
 from __future__ import annotations
 
-import json
+import copy
 import logging
 
-from .agents import _draft_table_schema, parse_json_response, stream_text
+from .agents import parse_json_response, stream_text
 from .config import Config, token_budget
 from .prepare import PreparedPaper
-from .schema import DraftClaimTable
+from .schema import DraftClaimTable, ReconciledClaim, ReviewPatch
 
 logger = logging.getLogger(__name__)
 
@@ -88,52 +88,94 @@ def build_review_request(paper: PreparedPaper, draft: DraftClaimTable,
     """The exact (system, user) the reviewer would send."""
     return load_reviewer_prompt(cfg), (
         f"{_format_paper_context(paper)}\n\n"
-        f"## Reconciled draft claim table (your input to revise)\n\n"
+        f"## Reconciled draft claim table (your input to patch)\n\n"
         f"```json\n{draft.model_dump_json(indent=2)}\n```\n\n"
-        f"Return the revised JSON claim table per your instructions. "
+        f"Return the patch JSON per your instructions. "
         f"JSON only — no surrounding prose."
     )
 
 
-def review_from_raw(raw: str, draft: DraftClaimTable) -> DraftClaimTable:
-    """Validate a raw reviewer answer into a revised DraftClaimTable.
+def _review_output_schema() -> dict:
+    """JSON schema for ReviewPatch, filtered to exclude runner-filled fields."""
+    from .agents import _filter_schema
+    raw = ReviewPatch.model_json_schema()
+    return _filter_schema(raw)
 
-    Every route in goes through here, so the fields the draft owns — how the paper was read,
-    the per-agent counts — survive whoever answered.
-    """
+
+def patch_from_raw(raw: str) -> ReviewPatch:
+    """Parse and validate a raw reviewer answer into a ReviewPatch."""
     parsed = parse_json_response(raw)
     if not isinstance(parsed, dict):
         raise ValueError(
             f"external reviewer returned non-dict JSON: {type(parsed).__name__}"
         )
+    return ReviewPatch(**parsed)
 
-    # Preserve fields the reviewer may have dropped
-    parsed.setdefault("paper_doi", draft.paper_doi)
-    parsed.setdefault("paper_title", draft.paper_title)
-    parsed.setdefault("paper_slug", draft.paper_slug)
-    # Assigned, not setdefault: how the paper was read is the draft's to state, and a
-    # reviewer that invented a value would overwrite it. The prompt no longer shows one,
-    # but the guarantee should not depend on the prompt.
-    parsed["extraction_path"] = draft.extraction_path
-    parsed["extraction_path_note"] = draft.extraction_path_note
-    parsed.setdefault("per_agent_counts", dict(draft.per_agent_counts))
-    parsed.setdefault("config_snapshot", dict(draft.config_snapshot))
 
-    # Stamp the snapshot with the review pass
-    parsed["config_snapshot"]["external_review"] = True
+def apply_patch(draft: DraftClaimTable, patch: ReviewPatch) -> DraftClaimTable:
+    """Apply a ReviewPatch to a DraftClaimTable, returning a revised copy.
 
-    return DraftClaimTable(**parsed)
+    - edits: update named fields of the matched claim (matched by `claim` sentence).
+    - additions: append new claims to the end of the list.
+    - Claims with no matching edit are returned unchanged.
+    - A claim sentence in `edits` that does not match any draft claim is logged
+      as a warning and skipped (the reviewer may have paraphrased).
+    """
+    # Index by claim sentence for O(1) lookup
+    claim_index: dict[str, int] = {c.claim: i for i, c in enumerate(draft.claims)}
+
+    # Deep copy so we don't mutate the caller's draft
+    revised_claims = [copy.deepcopy(c) for c in draft.claims]
+
+    for edit in patch.edits:
+        idx = claim_index.get(edit.claim)
+        if idx is None:
+            logger.warning(
+                "external reviewer edit: claim sentence not found in draft — skipped: %.80s",
+                edit.claim,
+            )
+            continue
+        claim = revised_claims[idx]
+        if edit.role is not None:
+            claim.role = edit.role
+        if edit.claim_type is not None:
+            claim.claim_type = edit.claim_type
+        if edit.panel is not None:
+            claim.panel = edit.panel
+        if edit.notes is not None:
+            claim.notes = edit.notes
+
+    for addition in patch.additions:
+        revised_claims.append(copy.deepcopy(addition))
+
+    # Build revised DraftClaimTable preserving all provenance fields
+    revised_data = draft.model_dump()
+    revised_data["claims"] = [c.model_dump() for c in revised_claims]
+    revised_data.setdefault("config_snapshot", {})
+    revised_data["config_snapshot"]["external_review"] = True
+    return DraftClaimTable(**revised_data)
+
+
+def review_from_raw(raw: str, draft: DraftClaimTable) -> tuple[DraftClaimTable, ReviewPatch]:
+    """Validate a raw reviewer answer and apply it to produce a revised DraftClaimTable.
+
+    Returns both the revised table and the raw patch, so the caller can write both.
+    """
+    patch = patch_from_raw(raw)
+    revised = apply_patch(draft, patch)
+    return revised, patch
+
 
 def external_review(
     paper: PreparedPaper,
     draft: DraftClaimTable,
     cfg: Config,
-) -> tuple[DraftClaimTable, dict]:
+) -> tuple[DraftClaimTable, ReviewPatch, dict]:
     """Run the external Opus reviewer pass on a reconciled draft.
 
-    Returns a revised DraftClaimTable. Preserves the original draft on
-    the caller side (caller is responsible for saving the original
-    separately if it wants both).
+    Returns (revised DraftClaimTable, raw ReviewPatch, usage dict).
+    Preserves the original draft on the caller side (caller is responsible for
+    saving the original separately if it wants both).
     """
     system_prompt, user_message = build_review_request(paper, draft, cfg)
 
@@ -148,7 +190,8 @@ def external_review(
         user=user_message,
         max_tokens=token_budget("external-reviewer", len(draft.claims)),
         label="external-reviewer",
-        output_schema=_draft_table_schema(),
+        output_schema=_review_output_schema(),
     )
 
-    return review_from_raw(raw, draft), usage
+    revised, patch = review_from_raw(raw, draft)
+    return revised, patch, usage

--- a/extract/elife_extract/external_review.py
+++ b/extract/elife_extract/external_review.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 
-from .agents import parse_json_response, stream_text
+from .agents import _draft_table_schema, parse_json_response, stream_text
 from .config import Config
 from .prepare import PreparedPaper
 from .schema import DraftClaimTable
@@ -148,6 +148,7 @@ def external_review(
         user=user_message,
         max_tokens=32768,
         label="external-reviewer",
+        output_schema=_draft_table_schema(),
     )
 
     return review_from_raw(raw, draft)

--- a/extract/elife_extract/layers.py
+++ b/extract/elife_extract/layers.py
@@ -22,7 +22,7 @@ import re
 from dataclasses import asdict
 from pathlib import Path
 
-from .config import Config
+from .config import Config, token_budget
 from .prepare import FigureCaption, PreparedPaper, TableCaption, prepare
 from .schema import AgentExtraction, DraftClaimTable
 from .write import _read_frontmatter, _write_key
@@ -350,7 +350,7 @@ def questions_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="questions")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="questions", max_tokens=token_budget("questions"))
 
     data = _validate_questions(parse_json_response(raw), paper, cfg)
     payload = {"paper_slug": paper, "model": model, **data}
@@ -523,7 +523,7 @@ def parts_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="parts")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="parts", max_tokens=token_budget("parts"))
 
     data = _validate_parts(parse_json_response(raw), paper, cfg)
     payload = {"paper_slug": paper, "model": model, **data}
@@ -754,7 +754,7 @@ def stance_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="stance")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="stance", max_tokens=token_budget("stance"))
 
     data = _validate_stance(parse_json_response(raw), paper, cfg)
     edges = _apply_stance(paper, data, cfg)
@@ -953,7 +953,7 @@ def summaries_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="summaries")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="summaries", max_tokens=token_budget("summaries"))
 
     entry = {**_validate_summary(parse_json_response(raw)), "model": model}
     path = _write_summary(paper, entry, cfg)
@@ -1007,7 +1007,7 @@ def synthesis_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="synthesis")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="synthesis", max_tokens=token_budget("synthesis"))
 
     data = _validate_synthesis(parse_json_response(raw), paper, cfg)
     payload = {"paperSlug": paper, "version": 3, **data, "model": model}
@@ -1105,7 +1105,7 @@ def abstract_map_layer(paper: str, cfg: Config, *,
         raw = p.read_text(encoding="utf-8")
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="abstract-map")
+        raw = stream_text(cfg, model=model, system=system, user=user, label="abstract-map", max_tokens=token_budget("abstract-map"))
 
     data = _validate_abstract_map(parse_json_response(raw), paper, cfg)
     payload = {"paperSlug": paper, **data, "model": model}

--- a/extract/elife_extract/layers.py
+++ b/extract/elife_extract/layers.py
@@ -218,6 +218,10 @@ def external_review_layer(paper: str, cfg: Config, *,
 
     Was `--review-mode external`. It is a step, not review: it changes the artifact, and it
     runs before the version it would have approved exists.
+
+    The reviewer now returns a patch (edits + additions) rather than a full replacement
+    table. The runner applies the patch, writes external-review.output.json (the revised
+    DraftClaimTable) and external-review.patch.json (the raw patch for audit).
     """
     from .external_review import external_review, review_from_raw
 
@@ -225,16 +229,18 @@ def external_review_layer(paper: str, cfg: Config, *,
         run_file(paper, "reconciler.output.json", cfg), "external-review", "reconcile"))
     if answer is not None:
         p, label = answer_file(answer, cfg)
-        revised = review_from_raw(p.read_text(encoding="utf-8"), draft)
+        revised, patch = review_from_raw(p.read_text(encoding="utf-8"), draft)
         revised.model = label
         rev_usage: dict = {}
     else:
-        revised, rev_usage = external_review(read_prepared(paper, cfg), draft, cfg)
+        revised, patch, rev_usage = external_review(read_prepared(paper, cfg), draft, cfg)
         revised.model = cfg.model_reconcile
     rev_payload = json.loads(revised.model_dump_json())
     if rev_usage:
         rev_payload["usage"] = rev_usage
     path = _write_json(run_file(paper, "external-review.output.json", cfg), rev_payload)
+    _write_json(run_file(paper, "external-review.patch.json", cfg),
+                json.loads(patch.model_dump_json()))
     return path, revised
 
 

--- a/extract/elife_extract/layers.py
+++ b/extract/elife_extract/layers.py
@@ -137,10 +137,13 @@ def reader_layer(agent: str, paper: str, cfg: Config, *,
     if answer is not None:
         p, label = answer_file(answer, cfg)
         extraction = reader_from_raw(agent, paper, label, p.read_text(encoding="utf-8"), prepared)
+        usage: dict = {}
     else:
-        extraction = run_agent(agent, prepared, cfg)
-    path = _write_json(run_file(paper, READER_OUTPUT[agent], cfg),
-                       json.loads(extraction.model_dump_json()))
+        extraction, usage = run_agent(agent, prepared, cfg)
+    payload = json.loads(extraction.model_dump_json())
+    if usage:
+        payload["usage"] = usage
+    path = _write_json(run_file(paper, READER_OUTPUT[agent], cfg), payload)
     return path, extraction
 
 
@@ -185,7 +188,7 @@ def reconcile_layer(paper: str, cfg: Config, *,
         path = _write_json(run_file(paper, "reconciler.output.json", cfg),
                            json.loads(draft.model_dump_json()))
         return path, draft
-    draft = reconcile(
+    draft, usage = reconcile(
         read_reader("results", paper, cfg),
         read_reader("caption", paper, cfg),
         read_reader("structure", paper, cfg),
@@ -195,8 +198,10 @@ def reconcile_layer(paper: str, cfg: Config, *,
         paper=prepared,
     )
     draft.model = cfg.model_reconcile
-    path = _write_json(run_file(paper, "reconciler.output.json", cfg),
-                       json.loads(draft.model_dump_json()))
+    payload = json.loads(draft.model_dump_json())
+    if usage:
+        payload["usage"] = usage
+    path = _write_json(run_file(paper, "reconciler.output.json", cfg), payload)
     return path, draft
 
 
@@ -222,11 +227,14 @@ def external_review_layer(paper: str, cfg: Config, *,
         p, label = answer_file(answer, cfg)
         revised = review_from_raw(p.read_text(encoding="utf-8"), draft)
         revised.model = label
+        rev_usage: dict = {}
     else:
-        revised = external_review(read_prepared(paper, cfg), draft, cfg)
+        revised, rev_usage = external_review(read_prepared(paper, cfg), draft, cfg)
         revised.model = cfg.model_reconcile
-    path = _write_json(run_file(paper, "external-review.output.json", cfg),
-                       json.loads(revised.model_dump_json()))
+    rev_payload = json.loads(revised.model_dump_json())
+    if rev_usage:
+        rev_payload["usage"] = rev_usage
+    path = _write_json(run_file(paper, "external-review.output.json", cfg), rev_payload)
     return path, revised
 
 
@@ -250,10 +258,11 @@ def edge_inference_layer(paper: str, cfg: Config) -> tuple[Path, list[dict]]:
     from .write import _unique_slugs
 
     draft, _ = best_draft(paper, cfg)
-    edges = infer_edges(draft, _unique_slugs(draft.claims), cfg)
-    path = _write_json(run_file(paper, "edge-inference.output.json", cfg), {
-        "paper_slug": paper, "model": cfg.model_reconcile, "edges": edges,
-    })
+    edges, edge_usage = infer_edges(draft, _unique_slugs(draft.claims), cfg)
+    edge_payload: dict = {"paper_slug": paper, "model": cfg.model_reconcile, "edges": edges}
+    if edge_usage:
+        edge_payload["usage"] = edge_usage
+    path = _write_json(run_file(paper, "edge-inference.output.json", cfg), edge_payload)
     return path, edges
 
 
@@ -348,12 +357,15 @@ def questions_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        q_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="questions", max_tokens=token_budget("questions"))
+        raw, q_usage = stream_text(cfg, model=model, system=system, user=user, label="questions", max_tokens=token_budget("questions"))
 
     data = _validate_questions(parse_json_response(raw), paper, cfg)
     payload = {"paper_slug": paper, "model": model, **data}
+    if q_usage:
+        payload["usage"] = q_usage
     path = _write_json(run_file(paper, "questions.output.json", cfg), payload)
     _apply_questions(paper, data, cfg)
     return path, payload
@@ -521,12 +533,15 @@ def parts_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        parts_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="parts", max_tokens=token_budget("parts"))
+        raw, parts_usage = stream_text(cfg, model=model, system=system, user=user, label="parts", max_tokens=token_budget("parts"))
 
     data = _validate_parts(parse_json_response(raw), paper, cfg)
     payload = {"paper_slug": paper, "model": model, **data}
+    if parts_usage:
+        payload["usage"] = parts_usage
     path = _write_json(run_file(paper, "parts.output.json", cfg), payload)
     _apply_parts(paper, data, cfg)
     return path, payload
@@ -752,13 +767,16 @@ def stance_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        stance_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="stance", max_tokens=token_budget("stance"))
+        raw, stance_usage = stream_text(cfg, model=model, system=system, user=user, label="stance", max_tokens=token_budget("stance"))
 
     data = _validate_stance(parse_json_response(raw), paper, cfg)
     edges = _apply_stance(paper, data, cfg)
     payload = {"paper_slug": paper, "model": model, **data, "edges": edges}
+    if stance_usage:
+        payload["usage"] = stance_usage
     path = _write_json(run_file(paper, "stance.output.json", cfg), payload)
     return path, payload
 
@@ -951,11 +969,14 @@ def summaries_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        sum_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="summaries", max_tokens=token_budget("summaries"))
+        raw, sum_usage = stream_text(cfg, model=model, system=system, user=user, label="summaries", max_tokens=token_budget("summaries"))
 
     entry = {**_validate_summary(parse_json_response(raw)), "model": model}
+    if sum_usage:
+        entry["usage"] = sum_usage
     path = _write_summary(paper, entry, cfg)
     return path, {"paper_slug": paper, **entry}
 
@@ -1005,12 +1026,15 @@ def synthesis_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        syn_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="synthesis", max_tokens=token_budget("synthesis"))
+        raw, syn_usage = stream_text(cfg, model=model, system=system, user=user, label="synthesis", max_tokens=token_budget("synthesis"))
 
     data = _validate_synthesis(parse_json_response(raw), paper, cfg)
     payload = {"paperSlug": paper, "version": 3, **data, "model": model}
+    if syn_usage:
+        payload["usage"] = syn_usage
     path = _write_json(site_data_file(cfg, "synthesis-v3", f"{paper}.json"), payload)
     return path, payload
 
@@ -1103,11 +1127,14 @@ def abstract_map_layer(paper: str, cfg: Config, *,
     if answer is not None:
         p, model = answer_file(answer, cfg)
         raw = p.read_text(encoding="utf-8")
+        amap_usage: dict = {}
     else:
         model = cfg.model_reconcile
-        raw = stream_text(cfg, model=model, system=system, user=user, label="abstract-map", max_tokens=token_budget("abstract-map"))
+        raw, amap_usage = stream_text(cfg, model=model, system=system, user=user, label="abstract-map", max_tokens=token_budget("abstract-map"))
 
     data = _validate_abstract_map(parse_json_response(raw), paper, cfg)
     payload = {"paperSlug": paper, **data, "model": model}
+    if amap_usage:
+        payload["usage"] = amap_usage
     path = _write_json(site_data_file(cfg, "abstract-mapping", f"{paper}.json"), payload)
     return path, payload

--- a/extract/elife_extract/prompts.py
+++ b/extract/elife_extract/prompts.py
@@ -19,13 +19,14 @@ from .contract import CONTRACT_DIR
 _VOCAB = f"{CONTRACT_DIR}/vocabulary.md"
 _CANDIDATE = f"{CONTRACT_DIR}/schema-candidate.md"
 _DRAFT = f"{CONTRACT_DIR}/schema-draft.md"
+_PATCH = f"{CONTRACT_DIR}/schema-review-patch.md"
 
 ROLES: dict[str, tuple[str, list[str]]] = {
     "results-reader": ("results-reader.md", [_VOCAB, _CANDIDATE]),
     "caption-reader": ("caption-reader.md", [_VOCAB, _CANDIDATE]),
     "structure-reader": ("structure-reader.md", [_VOCAB, _CANDIDATE]),
     "reconciler": ("reconciler.md", [_VOCAB, _DRAFT]),
-    "external-reviewer": ("external-reviewer.md", [_VOCAB, _DRAFT]),
+    "external-reviewer": ("external-reviewer.md", [_VOCAB, _DRAFT, _PATCH]),
     # Edge inference reads the vocabulary — where the relations, their directions and the
     # confusable pairs are defined — but not the claim schema: it returns edges, not claims.
     "edge-inference": ("edge-inference.md", [_VOCAB]),

--- a/extract/elife_extract/reconcile.py
+++ b/extract/elife_extract/reconcile.py
@@ -24,6 +24,7 @@ from .agents import (
     stream_text,
     verify_evidence,
 )
+from .config import token_budget
 from .config import Config
 from .prepare import PreparedPaper
 from .schema import AgentExtraction, DraftClaimTable, ReconciledClaim
@@ -235,7 +236,10 @@ def reconcile(
         model=cfg.model_reconcile,
         system=system_prompt,
         user=user_message,
-        max_tokens=32768,  # reconciliation output can be large; budget headroom
+        max_tokens=token_budget(
+            "reconciler",
+            len(results.claims) + len(caption.claims) + len(structure.claims),
+        ),
         label="reconciler",
         output_schema=_draft_table_schema(),
     )

--- a/extract/elife_extract/reconcile.py
+++ b/extract/elife_extract/reconcile.py
@@ -16,6 +16,7 @@ import json
 import logging
 
 from .agents import (
+    _draft_table_schema,
     _spans_by_uid,
     load_prompt,
     parse_json_response,
@@ -236,6 +237,7 @@ def reconcile(
         user=user_message,
         max_tokens=32768,  # reconciliation output can be large; budget headroom
         label="reconciler",
+        output_schema=_draft_table_schema(),
     )
     return draft_from_raw(raw, results, caption, structure, cfg, paper_doi,
                           paper_title, extraction_path, extraction_path_note, paper)

--- a/extract/elife_extract/reconcile.py
+++ b/extract/elife_extract/reconcile.py
@@ -207,7 +207,7 @@ def reconcile(
     extraction_path: str | None = None,
     extraction_path_note: str | None = None,
     paper: PreparedPaper | None = None,
-) -> DraftClaimTable:
+) -> tuple[DraftClaimTable, dict]:
     """Reconcile three extractions into a draft claim table via Opus.
 
     The reconciler sees all three lists at once. It returns a DraftClaimTable
@@ -231,7 +231,7 @@ def reconcile(
         len(structure.claims),
         cfg.model_reconcile,
     )
-    raw = stream_text(
+    raw, usage = stream_text(
         cfg,
         model=cfg.model_reconcile,
         system=system_prompt,
@@ -244,4 +244,4 @@ def reconcile(
         output_schema=_draft_table_schema(),
     )
     return draft_from_raw(raw, results, caption, structure, cfg, paper_doi,
-                          paper_title, extraction_path, extraction_path_note, paper)
+                          paper_title, extraction_path, extraction_path_note, paper), usage

--- a/extract/elife_extract/schema.py
+++ b/extract/elife_extract/schema.py
@@ -150,3 +150,33 @@ class DraftClaimTable(BaseModel):
         default_factory=dict,
         description="Filled by the runner: models and prompt variant. Leave empty.",
     )
+
+
+class ReviewEdit(BaseModel):
+    """One targeted change to an existing claim in the draft."""
+
+    claim: str = Field(..., description=(
+        "The exact `claim` sentence of the claim to edit, as it appears in the draft."))
+    role: Role | None = Field(None, description=(
+        "New role to assign; omit or null to leave unchanged."))
+    claim_type: ClaimType | None = Field(None, description=(
+        "New claim_type to assign; omit or null to leave unchanged."))
+    panel: str | None = Field(None, description=(
+        "New panel value; omit or null to leave unchanged."))
+    notes: str | None = Field(None, description=(
+        "Replacement notes string (prefix with [reviewer]); omit to leave unchanged."))
+
+
+class ReviewPatch(BaseModel):
+    """The external reviewer's output: targeted edits and new claims, not a full replacement.
+
+    The runner applies this patch to the reconciled draft, writes the revised
+    DraftClaimTable as external-review.output.json, and writes the raw patch
+    as external-review.patch.json for audit.
+    """
+
+    edits: list[ReviewEdit] = Field(default_factory=list, description=(
+        "Zero or more targeted changes to existing claims, keyed by their `claim` sentence."))
+    additions: list[ReconciledClaim] = Field(default_factory=list, description=(
+        "Zero or more new claims to append to the draft; each must carry "
+        "confidence=single-source and sources=[reviewer]."))

--- a/extract/prompts/contract/schema-review-patch.md
+++ b/extract/prompts/contract/schema-review-patch.md
@@ -1,0 +1,69 @@
+# What the external reviewer returns
+
+Generated from `extract/elife_extract/schema.py` by `elife-extract contract --write`. Do not edit.
+
+A single JSON object with two keys — `edits` and `additions` — and nothing else: no prose before or after, no code fence.
+
+Top level:
+
+| Field | Value | Meaning |
+|:--|:--|:--|
+| `edits` (optional) | list of ReviewEdit | Zero or more targeted changes to existing claims, keyed by their `claim` sentence. |
+| `additions` (optional) | list of ReconciledClaim | Zero or more new claims to append to the draft; each must carry confidence=single-source and sources=[reviewer]. |
+
+Each element of `edits` (targeted changes to existing claims):
+
+| Field | Value | Meaning |
+|:--|:--|:--|
+| `claim` | `string` | The exact `claim` sentence of the claim to edit, as it appears in the draft. |
+| `role` (optional) | `hypothesis` / `prediction` / `empirical` / `control` / `scope` / `methodological` / `synthesis` / `interpretation` / `literature-context` or `null` | New role to assign; omit or null to leave unchanged. |
+| `claim_type` (optional) | `empirical` / `interpretive` / `existence` / `synthesis` / `assessment` / `hypothesis` / `prediction` or `null` | New claim_type to assign; omit or null to leave unchanged. |
+| `panel` (optional) | `string` or `null` | New panel value; omit or null to leave unchanged. |
+| `notes` (optional) | `string` or `null` | Replacement notes string (prefix with [reviewer]); omit to leave unchanged. |
+
+Each element of `additions` (new claims appended to the draft):
+
+| Field | Value | Meaning |
+|:--|:--|:--|
+| `claim` | `string` | The canonical sentence. Where readers phrased one proposition differently, the most precise phrasing, grounded in their evidence. |
+| `panel` (optional) | `string` or `null` | As for a reader. Where readers disagree, the caption reader's panel. |
+| `claim_type` | `empirical` / `interpretive` / `existence` / `synthesis` / `assessment` / `hypothesis` / `prediction` | See the vocabulary. |
+| `role` | `hypothesis` / `prediction` / `empirical` / `control` / `scope` / `methodological` / `synthesis` / `interpretation` / `literature-context` | See the vocabulary. |
+| `addresses` (optional) | `string` or `null` | For a hypothesis or an alternative explanation, the research question it answers, as the paper states it or in one sentence; null for every other role. |
+| `confidence` | `high` / `contested` / `single-source` | A fact about agreement: single-source for one reader, high for several who agree, contested for several who disagree. |
+| `sources` | list of `results` / `caption` / `structure` / `reviewer` | The readers that surfaced this claim: results, caption, structure; reviewer for a claim the review pass added. |
+| `evidence_by_agent` (optional) | object | For each reader in sources, the verbatim quote it gave. |
+| `span_by_agent` (optional) | object | For each reader in sources that cited one, the span id its evidence quote came from. |
+| `evidence_verified` (optional) | object | Filled by the runner. Leave null. |
+| `evidence_verified_against` (optional) | object | Filled by the runner: per reader, `span` or `slice`. Leave null. |
+| `notes` (optional) | `string` or `null` | What the readers disagreed about, or why a single-source claim deserves a second look. A review pass prefixes its notes with [reviewer]. |
+| `part_of` (optional) | `string` or `null` | The exact `claim` sentence of another claim in this same table that this one is a component of — one comparison, condition, measure or study of a proposition that claim states whole. Keep both; the writer resolves the sentence to the whole's slug and writes `part-of`. null when this claim is not a part of another. |
+
+```json
+{
+  "edits": [
+    {
+      "claim": "Doubling distal dendritic inhibition reduces somatic firing from approximately 5.5 Hz to approximately 0.2 Hz.",
+      "role": "empirical",
+      "notes": "[reviewer] role: empirical \u2192 control. This result rules out that somatic firing is driven by distal input rather than proximal."
+    }
+  ],
+  "additions": [
+    {
+      "claim": "Distal inhibition more strongly reduces somatic firing than proximal inhibition.",
+      "panel": null,
+      "claim_type": "synthesis",
+      "role": "synthesis",
+      "addresses": null,
+      "confidence": "single-source",
+      "sources": [
+        "reviewer"
+      ],
+      "evidence_by_agent": {
+        "reviewer": "The contrast across fig4a (distal) and fig4b (proximal) is stated in the Discussion: distal inhibition is uniquely effective."
+      },
+      "notes": "[reviewer] added: synthesis across panels."
+    }
+  ]
+}
+```

--- a/extract/prompts/external-reviewer.md
+++ b/extract/prompts/external-reviewer.md
@@ -42,18 +42,20 @@ structure that the paper establishes across slices or leaves implicit:
 
 ## What you may and may not do
 
-You may change a claim's `role`, its `claim_type` when the role change requires it, and its
-`panel`; add claims; and write `notes`. You may not delete a claim, merge two claims, or add a
+You may change a claim's `role`, its `claim_type` when the role change requires it, its
+`panel`, and its `notes`; and add claims. You may not delete a claim, merge two claims, or add a
 number or a panel that appears neither in the prose you were given nor in the draft. A claim
-you think should go is kept, with `[reviewer] doubtful: …` in its notes.
+you think should go is kept; add an edit for it with `notes` set to `"[reviewer] doubtful: …"`.
 
-Mark every change. A revised claim's `notes` begins `[reviewer] role: empirical → control.`
-with the reason. An added claim has `confidence: single-source`, `sources: ["reviewer"]`, an
-`evidence_by_agent.reviewer` entry saying what in the prose or the draft it was inferred from,
-and notes beginning `[reviewer] added:`. An unchanged claim is returned exactly as it was.
+Mark every change. A claim you edit needs only the fields you are changing — list them in the
+`edits` array keyed by the exact `claim` sentence. A revised claim's `notes` begins
+`[reviewer] role: empirical → control.` with the reason. An added claim in `additions` must
+carry `confidence: "single-source"`, `sources: ["reviewer"]`, an `evidence_by_agent.reviewer`
+entry saying what in the prose or the draft it was inferred from, and `notes` beginning
+`[reviewer] added:`. Claims you do not change are omitted from `edits` — do not list them.
 
 ## What to return
 
-The complete revised table as the JSON object described below, and nothing else: no prose
-before or after it, no code fence. The vocabulary that follows defines every value you may
-use.
+A patch object with two keys — `edits` and `additions` — and nothing else: no prose before or
+after it, no code fence. The runner applies the patch to the draft, so you need only state the
+changes. The schema that follows defines every value you may use.

--- a/extract/tests/test_layer_contract.py
+++ b/extract/tests/test_layer_contract.py
@@ -174,7 +174,7 @@ def test_each_reader_writes_its_declared_path():
         _seed_prepared(root, cfg)
         decl = _declaration()
         for agent in ("results", "caption", "structure"):
-            with mock.patch.object(agents_mod, "run_agent", return_value=_extraction(agent)):
+            with mock.patch.object(agents_mod, "run_agent", return_value=(_extraction(agent), {})):
                 path, extraction = layers.reader_layer(agent, SLUG, cfg)
             declared = decl[f"{agent}-reader"]["produces"][0].replace("{paper}", SLUG)
             assert path == root / declared
@@ -196,7 +196,7 @@ def test_reconcile_reads_the_three_readers_from_disk():
 
         def fake_reconcile(results, caption, structure, cfg, **kw):
             seen["agents"] = [results.agent, caption.agent, structure.agent]
-            return _draft()
+            return _draft(), {}
 
         with mock.patch.object(reconcile_mod, "reconcile", fake_reconcile):
             path, draft = layers.reconcile_layer(SLUG, cfg)

--- a/pipeline/layers.yaml
+++ b/pipeline/layers.yaml
@@ -366,8 +366,8 @@ layers:
       on this output where it exists and on the reconciled draft where it does not.
     added: "2026-09-11"
     needs: [reconcile]
-    reads: [extract/prompts/external-reviewer.md, extract/prompts/contract/vocabulary.md, extract/prompts/contract/schema-draft.md]
-    produces: ["runs/{paper}/external-review.output.json"]
+    reads: [extract/prompts/external-reviewer.md, extract/prompts/contract/vocabulary.md, extract/prompts/contract/schema-draft.md, extract/prompts/contract/schema-review-patch.md]
+    produces: ["runs/{paper}/external-review.output.json", "runs/{paper}/external-review.patch.json"]
     views: [table, comparison]
     by_from: model
     command: "cd extract && python3 -m elife_extract.cli external-review --paper {paper}"

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -255,6 +255,27 @@ def _by_from_output(layer: dict, outs: list[str], paper: str | None = None) -> s
     return None
 
 
+def _usage_from_outputs(outs: list[str], root: str = ROOT) -> dict:
+    """Scan the layer's output JSON files for a top-level 'usage' dict; merge and return."""
+    merged: dict = {}
+    for path in outs:
+        if not path.endswith(".json") or "*" in path:
+            continue
+        full = os.path.join(root, path)
+        try:
+            with open(full, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            continue
+        usage = data.get("usage") if isinstance(data, dict) else None
+        if not isinstance(usage, dict):
+            continue
+        for key, val in usage.items():
+            if isinstance(val, (int, float)):
+                merged[key] = merged.get(key, 0) + val
+    return merged
+
+
 def record(paper: str, layer: dict, by_id: dict, *, note: str, by: str,
            doi: str | None = None) -> dict:
     """Build a run record for a layer that has just run, hashing what it read and wrote."""
@@ -263,7 +284,8 @@ def record(paper: str, layer: dict, by_id: dict, *, note: str, by: str,
     ins = inputs_of(layer, by_id, paper, doi)
     outs = expand(layer.get("produces"), paper, doi)
     by = _by_from_output(layer, outs, paper) or by
-    return {
+    usage = _usage_from_outputs(outs)
+    entry: dict = {
         "layer": layer["id"],
         "v": (prev["v"] + 1) if prev else 1,
         "ran": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -274,6 +296,9 @@ def record(paper: str, layer: dict, by_id: dict, *, note: str, by: str,
         "in_sets": input_sets(layer, by_id, paper, doi),
         "out": [{"path": r, "sha": digest(r)} for r in outs if digest(r)],
     }
+    if usage:
+        entry["usage"] = usage
+    return entry
 
 
 # ── state ─────────────────────────────────────────────────────────────────────

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -38,6 +38,7 @@ import shutil
 import subprocess
 import sys
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
 try:
@@ -577,6 +578,38 @@ def cmd_state(args) -> int:
     return 0
 
 
+def _wanted_waves(wanted: list, by_id: dict) -> list:
+    """Partition *wanted* (topological order) into depth-based waves.
+
+    Layers in the same wave have no dependency relationship with each other within the
+    wanted set, so they can run concurrently. The partition is: depth 0 has no
+    predecessors in wanted; depth k has only depth-(k-1)-or-lower predecessors.
+
+    The resulting list of lists preserves the overall topological order: all layers in
+    wave k complete before wave k+1 starts.
+    """
+    wanted_set = set(wanted)
+    depths: dict[str, int] = {}
+
+    def depth_of(lid):
+        if lid in depths:
+            return depths[lid]
+        d = max(
+            (depth_of(dep) + 1 for dep in (by_id[lid].get("needs") or []) if dep in wanted_set),
+            default=0,
+        )
+        depths[lid] = d
+        return d
+
+    for lid in wanted:
+        depth_of(lid)
+
+    if not depths:
+        return []
+    max_d = max(depths.values())
+    return [[lid for lid in wanted if depths[lid] == d] for d in range(max_d + 1)]
+
+
 def cmd_run(args) -> int:
     """Run a layer for one paper, and its unmet dependencies first.
 
@@ -628,25 +661,31 @@ def cmd_run(args) -> int:
 
     doi = _doi_of(args.paper)
     ran = 0
-    for lid in wanted:
+    jobs = getattr(args, "jobs", 1)
+
+    def _prepare_one(lid):
+        """Check skip conditions and build the shell command for one layer.
+
+        Returns a dict with keys:
+          skip:   True if the layer should not run (or None for fatal skips)
+          fatal:  True if the skip is a caller error (return code 3)
+          cmd:    the shell command string (None when skip=True)
+          answered_kept: path of the kept answer file (None when not --answer)
+        """
         layer = by_id[lid]
         if layer.get("scope") == "corpus":
-            continue
+            return {"skip": True, "fatal": False, "cmd": None, "answered_kept": None}
         cur = st.get(lid, {}).get("state")
         if lid != args.layer and cur == CURRENT:
-            continue
+            return {"skip": True, "fatal": False, "cmd": None, "answered_kept": None}
         if layer.get("requires_human"):
             print(f"  {lid}: requires a person — not runnable from here")
-            if lid == args.layer:
-                return 3
-            continue
+            return {"skip": True, "fatal": lid == args.layer, "cmd": None, "answered_kept": None}
         cmd = layer.get("command")
         if not cmd:
             print(f"  {lid}: no runner declared — skipping"
                   f"{' (this is the layer you asked for)' if lid == args.layer else ''}")
-            if lid == args.layer:
-                return 3
-            continue
+            return {"skip": True, "fatal": lid == args.layer, "cmd": None, "answered_kept": None}
 
         cmd = cmd.replace("{paper}", args.paper).replace("{doi}", doi or "")
         # An answer made somewhere other than the configured backend — a subagent, a person —
@@ -655,6 +694,7 @@ def cmd_run(args) -> int:
         # hand, which recorded nothing, and the first end-to-end run of the chain had to live
         # in experiments/ because the ledger could not hold it.
         answered = args.answer if lid == args.layer and args.answer else None
+        answered_kept = None
         if answered:
             # The raw reply is kept beside the output, before validation and under the
             # version it will get: a verdict whose prompt and output are not both recorded
@@ -662,36 +702,77 @@ def cmd_run(args) -> int:
             # is handed the kept copy, so the output's `model` field names a path in the
             # repository rather than wherever the reply happened to be written.
             prev = _latest(read_ledger(args.paper), lid)
-            kept = os.path.join("runs", args.paper,
-                                f"{lid}.answer.v{(prev['v'] + 1) if prev else 1}.json")
-            os.makedirs(os.path.dirname(os.path.join(ROOT, kept)), exist_ok=True)
-            shutil.copyfile(answered, os.path.join(ROOT, kept))
-            cmd += f" --answer {shlex.quote(kept)}"
+            answered_kept = os.path.join(
+                "runs", args.paper,
+                f"{lid}.answer.v{(prev['v'] + 1) if prev else 1}.json",
+            )
+            os.makedirs(os.path.dirname(os.path.join(ROOT, answered_kept)), exist_ok=True)
+            shutil.copyfile(answered, os.path.join(ROOT, answered_kept))
+            cmd += f" --answer {shlex.quote(answered_kept)}"
         print(f"  {lid}: {cmd}")
-        if args.dry_run:
+        return {"skip": False, "fatal": False, "cmd": cmd, "answered_kept": answered_kept}
+
+    def _run_one(lid, prep):
+        """Run a prepared layer's command. Returns (rc, lid)."""
+        rc = subprocess.run(prep["cmd"], shell=True, cwd=ROOT).returncode
+        return rc, lid
+
+    for wave in _wanted_waves(wanted, by_id):
+        # Prepare every layer in this wave (skip checks, build cmds).
+        preps = {lid: _prepare_one(lid) for lid in wave}
+
+        # Check for fatal skips before launching anything.
+        for lid in wave:
+            if preps[lid]["fatal"]:
+                return 3
+
+        # Collect the runnable layers (not skipped, not dry-run).
+        runnable = [lid for lid in wave if not preps[lid]["skip"]]
+        if args.dry_run or not runnable:
             continue
-        rc = subprocess.run(cmd, shell=True, cwd=ROOT).returncode
-        if rc != 0:
-            print(f"  {lid}: exited {rc}", file=sys.stderr)
-            return rc
-        rec = record(args.paper, layer, by_id,
-                     note=args.note or "ran via scripts/pipeline.py",
-                     by="scripts/pipeline.py run", doi=doi)
-        # The command is the record. Deriving `by` from its first token gave "cd" for every
-        # layer whose command starts by changing directory.
-        rec["cmd"] = cmd
-        if answered:
-            rec["answer"] = {"path": kept, "sha": digest(kept)}
-            # The output can only say the answer was supplied; who supplied it is known to
-            # whoever ran this, and is the fact the ledger exists to keep.
-            if args.by:
-                rec["by"] = args.by
-        append(args.paper, rec)
-        # Keep this version's bytes addressable for the site's two-version comparison. Only
-        # single files under runs/; claims/ archives itself into claim-tree.v<N>/.
-        for kept in keep_versions(rec):
-            print(f"  {lid}: kept {kept}")
-        ran += 1
+
+        # Run the wave — concurrently when jobs > 1 and the wave has multiple layers.
+        results: dict[str, int] = {}  # lid -> returncode
+        if jobs > 1 and len(runnable) > 1:
+            with ThreadPoolExecutor(max_workers=min(jobs, len(runnable))) as pool:
+                futures = {pool.submit(_run_one, lid, preps[lid]): lid for lid in runnable}
+                for fut in as_completed(futures):
+                    rc, lid = fut.result()
+                    results[lid] = rc
+        else:
+            for lid in runnable:
+                rc, _ = _run_one(lid, preps[lid])
+                results[lid] = rc
+
+        # Write ledger entries in deterministic (wanted) order after all subprocesses finish.
+        # This ensures no interleaving even when the wave ran in parallel.
+        for lid in wave:
+            if lid not in results:
+                continue
+            rc = results[lid]
+            if rc != 0:
+                print(f"  {lid}: exited {rc}", file=sys.stderr)
+                return rc
+            layer = by_id[lid]
+            rec = record(args.paper, layer, by_id,
+                         note=args.note or "ran via scripts/pipeline.py",
+                         by="scripts/pipeline.py run", doi=doi)
+            # The command is the record. Deriving `by` from its first token gave "cd" for
+            # every layer whose command starts by changing directory.
+            rec["cmd"] = preps[lid]["cmd"]
+            answered_kept = preps[lid]["answered_kept"]
+            if answered_kept:
+                rec["answer"] = {"path": answered_kept, "sha": digest(answered_kept)}
+                # The output can only say the answer was supplied; who supplied it is known
+                # to whoever ran this, and is the fact the ledger exists to keep.
+                if args.by:
+                    rec["by"] = args.by
+            append(args.paper, rec)
+            # Keep this version's bytes addressable for the site's two-version comparison.
+            # Only single files under runs/; claims/ archives itself into claim-tree.v<N>/.
+            for kept in keep_versions(rec):
+                print(f"  {lid}: kept {kept}")
+            ran += 1
 
     print(f"\n{ran} layer(s) run" + (" (dry run)" if args.dry_run else ""))
     return 0
@@ -764,6 +845,8 @@ def main() -> int:
     r.add_argument("layer")
     r.add_argument("--no-deps", action="store_true", help="run only the named layer")
     r.add_argument("--dry-run", action="store_true", help="print the commands, run nothing")
+    r.add_argument("--jobs", type=int, default=3, metavar="N",
+                   help="max concurrent layer commands within a wave (default: 3)")
     r.add_argument("--note", help="the changelog line for the ledger entry")
     r.add_argument("--answer", metavar="FILE",
                    help="record this file as the named layer's answer instead of calling a "


### PR DESCRIPTION
## Part 1 — Provider-enforced structured outputs

Replace the `parse_json_response`/`_as_claim_list` salvage path with provider-enforced
structured outputs. The Anthropic path uses `output_config={"format": {...}}` with a JSON
schema derived from the pydantic models (excluding "Filled by the runner" fields). The
litellm path uses `response_format`. Salvage code is kept only for `--answer` (free text)
and as a fallback. Each reply logs which path it took.

## Part 2 — Per-layer token budgets

Replace the hardcoded `max_tokens=32768` with per-layer budgets derived from expected output
size: ~450 tokens per expected claim for readers, draft size ×2 (900/claim) for
reconcile/review, 60 per claim for edges, small fixed budgets for questions/parts/summaries.
The budget table lives in `config.py::_BUDGET_TABLE` and is accessed via `token_budget(label,
n_claims)`.

## Part 3 — Concurrent independent layers (`--jobs N`)

When several absent/stale layers at the same dependency depth share no dependencies on each
other, run their commands concurrently in `pipeline.py run` via `--jobs N` (default 3).
Depth-based topological leveling computes waves; a `ThreadPoolExecutor` runs each wave's
subprocesses in parallel. Ledger writes are deferred until all wave subprocesses complete,
then written in the wanted-list order (deterministic, no interleaving).

## Part 4 — Cached prompts, adaptive thinking, and usage recorded per layer

Add `cache_control={"type": "ephemeral"}` on all Anthropic system blocks. Add adaptive
thinking (`thinking={"type": "adaptive"}`) for Claude 4.6+/5 models; effort `high` for
reconcile/review/edges/parts, `medium` for readers. `stream_text()` now returns `(str, dict)`
carrying `input_tokens`, `output_tokens`, `cache_read_input_tokens`,
`cache_creation_input_tokens`. Every layer writes usage into its output JSON and
`pipeline.record()` reads it back into each ledger entry.

## Part 5 — External reviewer output as a patch

Change external reviewer output from a full replacement `DraftClaimTable` to a patch format
`{"edits": [...], "additions": [...]}`. The runner applies the patch with `apply_patch()`,
writes `external-review.output.json` (revised draft) and `external-review.patch.json` (raw
patch for audit). Add `ReviewEdit` and `ReviewPatch` pydantic models to `schema.py`, generate
`extract/prompts/contract/schema-review-patch.md`, update `ROLES` for `external-reviewer`,
and update the prompt to describe the new output format.

---

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)