### PR TITLE
feat(site): the claim graph in role bands, and what MIRA can read of it

### DIFF
--- a/site/src/components/ClaimDAG.tsx
+++ b/site/src/components/ClaimDAG.tsx
@@ -8,8 +8,6 @@ import ReactFlow, {
   type Node,
   type Edge,
   type NodeTypes,
-  useNodesState,
-  useEdgesState,
   useReactFlow,
   ReactFlowProvider,
   Panel,
@@ -17,6 +15,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import dagre from '@dagrejs/dagre';
 import { nodeColor, outcomeOf, OUTCOME_LABEL, OUTCOME_COLOR } from '../lib/status';
+import { readableInCoreMira, MIRA_PARENT, MIRA_INVERSE_OF } from '../lib/mira';
 import { useFitOnReveal } from './useFitOnReveal';
 
 interface Claim {
@@ -35,7 +34,7 @@ interface Claim {
 
 // The corpus defines fourteen relation types and this component drew two of them. On Gädeke
 // that was 9 edges out of 89, so the graph arrived as a field of unconnected dots and fitView
-// shrank it to 20%. With all fourteen the same 33 claims are a single connected component.
+// shrank it to 20%. With all fourteen the same claims are a single connected component.
 //
 // Four families rather than fourteen colours: a reader can hold four. The reasoning form of
 // each edge is in docs/reference/edges.
@@ -54,6 +53,45 @@ const FAMILY: Record<string, { stroke: string; dash?: string; label: string }> =
   test:       { stroke: 'var(--dag-edge-test)', dash: '2 3', label: 'tests · rules out' },
   framing:    { stroke: 'var(--dag-edge-framing)', dash: '1 4', label: 'interprets · scopes' },
 };
+
+// In the MIRA view an edge keeps only what a core-MIRA consumer can read off it: support or
+// opposition. Both colours are the ones this graph already spends on those meanings, so the
+// view changes what is said, not the vocabulary it is said in.
+const MIRA_STROKE: Record<string, string> = {
+  'mira:supports': 'var(--dag-edge-support)',
+  'mira:opposes': 'var(--dag-edge-test)',
+};
+
+// ── Role bands ───────────────────────────────────────────────────────────────
+// dagre ranks a node by its distance along the edges, which is a fact about the drawing and
+// not about the paper: a control that happens to sit two edges from a hypothesis was drawn
+// level with the predictions, and the picture had no shape a reader could name. The bands
+// below are the paper's own division of labour, and the deductive spine — hypothesis, the
+// prediction it entails, the result that tests the prediction — reads straight down them.
+//
+// The ten roles are corpus-facts.roles_used; every one has a home here, and a role that
+// appears later without one lands in Findings rather than vanishing.
+const BANDS: { id: string; label: string; roles: string[] }[] = [
+  { id: 'hypothesis',     label: 'Hypotheses',           roles: ['hypothesis'] },
+  { id: 'prediction',     label: 'Predictions',          roles: ['prediction'] },
+  { id: 'empirical',      label: 'Findings',             roles: ['empirical'] },
+  { id: 'interpretation', label: 'Interpretation',       roles: ['interpretation', 'synthesis', 'assessment'] },
+  { id: 'control',        label: 'Controls and methods', roles: ['control', 'methodological'] },
+  { id: 'context',        label: 'Scope and prior work', roles: ['scope', 'literature-context'] },
+];
+const BAND_OF_ROLE: Record<string, string> = {};
+for (const b of BANDS) for (const r of b.roles) BAND_OF_ROLE[r] = b.id;
+
+const NODE_WIDTH = 150;
+const NODE_HEIGHT = 50;
+const COL_GAP = 22;
+const ROW_GAP = 16;
+const BAND_GAP = 52;
+const LABEL_GUTTER = 148;
+// A band wider than this wraps onto a second row. Gädeke's Findings band is 23 claims: on one
+// row that is 4000px against six bands of 600px, and fitView answers a 7:1 canvas with a zoom
+// at which no label is legible. Wrapped, the bands stay bands and the page stays readable.
+const MAX_PER_ROW = 8;
 
 interface Props {
   claims: Claim[];
@@ -121,22 +159,54 @@ function ClaimNode({ data }: { data: any }) {
   );
 }
 
-const nodeTypes: NodeTypes = { claimNode: ClaimNode as any };
+/** A band's name, in the gutter to the left of its rows. It sits outside the span the claims
+ *  occupy so no edge ever crosses it, and carries a rule down the band's height so the band
+ *  has a visible extent without a fill competing with the nodes. */
+function BandNode({ data }: { data: any }) {
+  return (
+    <div
+      style={{
+        width: LABEL_GUTTER - 22,
+        height: data.height,
+        borderRight: '1px solid var(--dag-panel-border)',
+        paddingRight: 10,
+        boxSizing: 'border-box',
+        display: 'flex',
+        justifyContent: 'flex-end',
+        pointerEvents: 'none',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: '0.07em',
+          textTransform: 'uppercase',
+          color: 'var(--dag-panel-fg)',
+          opacity: 0.55,
+          whiteSpace: 'nowrap',
+          lineHeight: `${NODE_HEIGHT}px`,
+        }}
+      >
+        {data.label}
+      </span>
+    </div>
+  );
+}
 
-const NODE_WIDTH = 150;
-const NODE_HEIGHT = 50;
+const nodeTypes: NodeTypes = { claimNode: ClaimNode as any, bandNode: BandNode as any };
 
-function layoutGraph(claims: Claim[]): { nodes: Node[]; edges: Edge[] } {
-  const g = new dagre.graphlib.Graph();
-  g.setDefaultEdgeLabel(() => ({}));
-  g.setGraph({ rankdir: 'BT', ranksep: 58, nodesep: 16, edgesep: 10, marginx: 14, marginy: 14 });
+interface Built {
+  nodes: Node[];
+  edges: Edge[];
+}
 
+function layoutGraph(claims: Claim[]): Built {
   const present = new Set(claims.map(c => c.slug));
-  for (const c of claims) g.setNode(c.slug, { width: NODE_WIDTH, height: NODE_HEIGHT });
 
+  // ── the edges the reader can see ──
   const edges: Edge[] = [];
   const seen = new Set<string>();
-
   for (const c of claims) {
     for (const rel of RELATIONS) {
       const targets: string[] = Array.isArray(c[rel]) ? c[rel] : [];
@@ -147,86 +217,196 @@ function layoutGraph(claims: Claim[]): { nodes: Node[]; edges: Edge[] } {
         const id = `${rel}-${c.slug}-${t}`;
         if (seen.has(id)) continue;
         seen.add(id);
-        const family = REL_FAMILY[rel];
-        const fam = FAMILY[family];
-        // Framing relations are drawn but do not rank the layout. `scopes` alone is 29 of
-        // Gädeke's 89 edges and ties one boundary-condition claim to most of the paper; letting
-        // it constrain the ranking splayed a single row across 2700px and fitView answered with
-        // 30% zoom. The argument's spine is dependency, support and test.
-        if (family !== 'framing') g.setEdge(t, c.slug);
         edges.push({
           id,
           source: t,
           target: c.slug,
           type: 'smoothstep',
           data: { rel },
-          style: { stroke: fam.stroke, strokeWidth: 1.4, strokeDasharray: fam.dash },
-          markerEnd: { type: 'arrowclosed' as any, width: 11, height: 11, color: fam.stroke },
         });
       }
     }
   }
 
+  // ── horizontal order, seeded by dagre ──
+  // The bands fix y, so dagre is asked for one thing only: an ordering across the page that
+  // does not cross more edges than it must. Its ranks are discarded.
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: 'BT', ranksep: 58, nodesep: 16, edgesep: 10, marginx: 14, marginy: 14 });
+  for (const c of claims) g.setNode(c.slug, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  for (const e of edges) {
+    // Framing relations are drawn but do not order the layout. `scopes` alone is a large
+    // share of Gädeke's edges and ties one boundary-condition claim to most of the paper;
+    // letting it pull the ordering splays a band across the page for no gain.
+    if (REL_FAMILY[(e.data as any).rel] !== 'framing') g.setEdge(e.source, e.target);
+  }
   dagre.layout(g);
+  const seedX: Record<string, number> = {};
+  for (const c of claims) seedX[c.slug] = g.node(c.slug)?.x ?? 0;
 
-  const nodes: Node[] = claims.map(c => {
-    const pos = g.node(c.slug);
-    return {
-      id: c.slug,
-      type: 'claimNode',
-      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
-      data: { ...c, dimmed: false },
-    };
+  // ── assign to bands, drop the empty ones ──
+  const members: Record<string, Claim[]> = {};
+  for (const c of claims) {
+    const band = BAND_OF_ROLE[(c as any).role] ?? 'empirical';
+    (members[band] ||= []).push(c);
+  }
+  const live = BANDS.filter(b => (members[b.id] ?? []).length > 0);
+
+  // Two barycentre sweeps over the dagre seed. A node wants to sit above or below the things
+  // it is joined to, and the seed's ordering was computed for ranks these bands do not use.
+  const neighbours: Record<string, string[]> = {};
+  for (const e of edges) {
+    if (REL_FAMILY[(e.data as any).rel] === 'framing') continue;
+    (neighbours[e.source] ||= []).push(e.target);
+    (neighbours[e.target] ||= []).push(e.source);
+  }
+  const order: Record<string, number> = { ...seedX };
+  for (let sweep = 0; sweep < 2; sweep++) {
+    const next: Record<string, number> = {};
+    for (const c of claims) {
+      const ns = neighbours[c.slug] ?? [];
+      next[c.slug] = ns.length
+        ? ns.reduce((s, n) => s + (order[n] ?? 0), 0) / ns.length
+        : order[c.slug];
+    }
+    // Ties are broken by the previous order, so a band of unconnected claims keeps a stable
+    // arrangement rather than reshuffling on every render.
+    for (const c of claims) order[c.slug] = (next[c.slug] + order[c.slug]) / 2;
+  }
+
+  // ── rows within each band ──
+  const laid = live.map(band => {
+    const list = [...(members[band.id] ?? [])].sort(
+      (a, b) => (order[a.slug] - order[b.slug]) || a.slug.localeCompare(b.slug));
+    const rowCount = Math.ceil(list.length / MAX_PER_ROW);
+    // Spread evenly rather than filling the first row and leaving a stub on the second.
+    const even = Math.ceil(list.length / rowCount);
+    const rows: Claim[][] = [];
+    for (let i = 0; i < list.length; i += even) rows.push(list.slice(i, i + even));
+    return { band, rows };
   });
+
+  // ── place, every band centred on one axis ──
+  // Centring each band inside its own width would step the narrow bands off the wide ones and
+  // the spine would zigzag. The page has one centre line and all six bands sit on it.
+  const rowWidth = (n: number) => n * NODE_WIDTH + (n - 1) * COL_GAP;
+  const canvasWidth = Math.max(...laid.flatMap(l => l.rows.map(r => rowWidth(r.length))));
+
+  const nodes: Node[] = [];
+  let y = 0;
+  for (const { band, rows } of laid) {
+    const bandHeight = rows.length * NODE_HEIGHT + (rows.length - 1) * ROW_GAP;
+
+    nodes.push({
+      id: `band-${band.id}`,
+      type: 'bandNode',
+      position: { x: -LABEL_GUTTER, y },
+      data: { label: band.label, height: bandHeight },
+      draggable: false,
+      selectable: false,
+      connectable: false,
+      focusable: false,
+      zIndex: -1,
+    });
+
+    rows.forEach((row, ri) => {
+      const x0 = (canvasWidth - rowWidth(row.length)) / 2;
+      row.forEach((c, ci) => {
+        nodes.push({
+          id: c.slug,
+          type: 'claimNode',
+          position: { x: x0 + ci * (NODE_WIDTH + COL_GAP), y: y + ri * (NODE_HEIGHT + ROW_GAP) },
+          data: { ...c, dimmed: false },
+        });
+      });
+    });
+
+    y += bandHeight + BAND_GAP;
+  }
 
   return { nodes, edges };
 }
 
 function DAGInner({ claims, paperSlug }: Props) {
-  const { nodes: initialNodes, edges: initialEdges } = useMemo(() => layoutGraph(claims), [claims]);
-  const [nodes, setNodes] = useNodesState(initialNodes);
-  const [edges, setEdges] = useEdgesState(initialEdges);
+  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => layoutGraph(claims), [claims]);
   // Off by default: a reader arriving at a claim tree should see the paper's argument, not a
   // scorecard of what we managed to re-run.
   const [showRepro, setShowRepro] = useState(false);
-  const shell = useFitOnReveal<HTMLDivElement>(0.15);
+  // Which interchange format the graph is read through. `corpus` is this project's own
+  // vocabulary; `mira` is what survives into the schema eLife reads.
+  const [mode, setMode] = useState<'corpus' | 'mira'>('corpus');
+  const [active, setActive] = useState<Set<string> | null>(null);
+  // The graph lives in a <details> inside a column the rail resizes, so its box keeps moving
+  // for a while after it appears. Fit until it stops, then leave the reader alone.
+  const shell = useFitOnReveal<HTMLDivElement>(0.15, { refitOnResize: true });
 
-  // Repainting the whole graph when the layer is switched, rather than reading the flag from
-  // a context in each node — the node count here is small and this keeps the node dumb.
-  React.useEffect(() => {
-    setNodes(nds => nds.map(n => ({ ...n, data: { ...n.data, repro: showRepro } })));
-  }, [showRepro, setNodes]);
-
-  // Build adjacency for highlighting
   const claimBySlug = useMemo(() => {
     const m: Record<string, Claim> = {};
     for (const c of claims) m[c.slug] = c;
     return m;
   }, [claims]);
 
+  // What the MIRA view costs, counted off the edges actually drawn rather than off a table —
+  // so the number in the banner is the number of lines that left the picture.
+  const loss = useMemo(() => {
+    const dropped = baseEdges.filter(e => !readableInCoreMira((e.data as any).rel));
+    const byType: Record<string, number> = {};
+    for (const e of dropped) {
+      const rel = (e.data as any).rel as string;
+      byType[rel] = (byType[rel] ?? 0) + 1;
+    }
+    const types = Object.keys(byType).sort((a, b) => byType[b] - byType[a]);
+    return { count: dropped.length, total: baseEdges.length, types, byType };
+  }, [baseEdges]);
+
+  const edges = useMemo(() => baseEdges.flatMap(e => {
+    const rel = (e.data as any).rel as string;
+    const dim = active && !(active.has(e.source) && active.has(e.target));
+    let stroke: string;
+    let dash: string | undefined;
+    if (mode === 'mira') {
+      const parent = MIRA_PARENT[rel];
+      if (!parent) return [];
+      stroke = MIRA_STROKE[parent];
+      dash = undefined;
+    } else {
+      const fam = FAMILY[REL_FAMILY[rel]];
+      stroke = fam.stroke;
+      dash = fam.dash;
+    }
+    return [{
+      ...e,
+      style: { stroke, strokeWidth: 1.4, strokeDasharray: dash, opacity: dim ? 0.15 : 1 },
+      markerEnd: { type: 'arrowclosed' as any, width: 11, height: 11, color: stroke },
+    }];
+  }), [baseEdges, mode, active]);
+
+  const nodes = useMemo(() => baseNodes.map(n => (
+    n.type === 'bandNode'
+      ? n
+      : { ...n, data: { ...n.data, repro: showRepro, dimmed: Boolean(active && !active.has(n.id)) } }
+  )), [baseNodes, showRepro, active]);
+
   const onNodeClick = useCallback((_: any, node: Node) => {
     const claim = claimBySlug[node.id];
     if (!claim) return;
     // The same event the claim cards and summary bullets dispatch. The graph used to carry
     // its own sidebar, which made three panels on one page saying the same thing in three
-    // different shapes.
+    // different shapes — and is why the verification record went into the rail's card rather
+    // than into a second panel here.
     window.dispatchEvent(new CustomEvent('open-claim', { detail: { slug: claim.slug } }));
 
-    // Follow the edges the reader can see, not just `requires`. Adjacency is built once
-    // from the same relation set the layout used.
-    const ancestors = new Set<string>();
-    const descendants = new Set<string>();
+    // Follow the edges the reader can see, not just `requires`. In the MIRA view that means
+    // the edges MIRA can still read: the neighbourhood shrinks with the picture, which is
+    // the thing the view is there to show.
+    const visible = baseEdges.filter(e =>
+      mode === 'corpus' || readableInCoreMira((e.data as any).rel));
     const up: Record<string, string[]> = {};
     const down: Record<string, string[]> = {};
-    for (const c of claims) {
-      for (const rel of RELATIONS) {
-        const targets: string[] = Array.isArray(c[rel]) ? c[rel] : [];
-        for (const t of targets) {
-          if (t === '*' || !claimBySlug[t]) continue;
-          (up[c.slug] ||= []).push(t);
-          (down[t] ||= []).push(c.slug);
-        }
-      }
+    for (const e of visible) {
+      (up[e.target] ||= []).push(e.source);
+      (down[e.source] ||= []).push(e.target);
     }
     const walk = (from: string, adj: Record<string, string[]>, into: Set<string>) => {
       const stack = [from];
@@ -238,58 +418,86 @@ function DAGInner({ claims, paperSlug }: Props) {
         }
       }
     };
-    walk(node.id, up, ancestors);
-    walk(node.id, down, descendants);
+    const reached = new Set<string>([node.id]);
+    walk(node.id, up, reached);
+    walk(node.id, down, reached);
+    setActive(reached);
+  }, [claimBySlug, baseEdges, mode]);
 
-    const active = new Set([node.id, ...ancestors, ...descendants]);
+  const onPaneClick = useCallback(() => setActive(null), []);
 
-    setNodes(nds => nds.map(n => ({
-      ...n,
-      data: { ...n.data, dimmed: !active.has(n.id) },
-    })));
-
-    setEdges(eds => eds.map(e => ({
-      ...e,
-      style: {
-        ...e.style,
-        opacity: (active.has(e.source) && active.has(e.target)) ? 1 : 0.15,
-      },
-    })));
-  }, [claimBySlug, claims]);
-
-  const onPaneClick = useCallback(() => {
-    setNodes(nds => nds.map(n => ({ ...n, data: { ...n.data, dimmed: false } })));
-    setEdges(eds => eds.map(e => ({ ...e, style: { ...e.style, opacity: 1 } })));
-  }, []);
-
-  const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+  // Only a real gesture stops the auto-fit. fitView moves the viewport itself and fires
+  // onMoveStart with no event, which otherwise locks the graph at the first fit it was given.
+  const onMoveStart = useCallback((e: any) => { if (e) shell.settle(); }, [shell]);
 
   return (
-    <div ref={shell} className="dag-shell h-full w-full">
-      <div className="h-full w-full">
+    <div ref={shell} className="dag-shell flex h-full w-full flex-col">
+      {/* The format switch. The site reports elsewhere, in a table, that MIRA carries almost
+          every relation in the corpus; that is true of the triples and says nothing about
+          whether they can be read. One click is the argument. */}
+      <div className="dag-formatbar">
+        <div className="dag-formatrow">
+          <div className="dag-seg" role="group" aria-label="Interchange format">
+            {([['corpus', 'This corpus'], ['mira', 'MIRA']] as const).map(([id, label]) => (
+              <button key={id} type="button" aria-pressed={mode === id}
+                      onClick={() => setMode(id)}>{label}</button>
+            ))}
+          </div>
+          <p className="dag-formatnote">
+            {mode === 'corpus'
+              ? <>All {loss.total} relations between these claims, in the fourteen types the corpus defines.</>
+              : <>The same graph as a reader of core MIRA sees it: <strong>{loss.count} of {loss.total} relations
+                  gone</strong>, and the rest flattened to support or opposition.</>}
+          </p>
+        </div>
+        {mode === 'mira' && loss.count > 0 && (
+          <p className="dag-formatloss">
+            Hidden: {loss.types.map(t => `${t} (${loss.byType[t]})`).join(', ')}.
+            {' '}These types declare no core MIRA predicate, so they are exported as bare
+            {' '}<code>haak:reldef</code> terms with no parent: the triples are in the file, but
+            {' '}nothing tells a consumer that knows only <code>mira:supports</code> and
+            {' '}<code>mira:opposes</code> what they assert.
+            {loss.types.some(t => MIRA_INVERSE_OF[t]) && (
+              <> <code>derived-from</code> reaches MIRA only as its inverse, <code>entails</code>,
+                {' '}which declares no parent either.</>
+            )}
+          </p>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1">
         <ReactFlow
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
+          onMoveStart={onMoveStart}
           nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={true}
           fitView
           fitViewOptions={{ padding: 0.15 }}
-          minZoom={0.2}
+          minZoom={0.1}
           maxZoom={3}
           proOptions={{ hideAttribution: true }}
         >
           <Background color="var(--dag-grid)" gap={20} />
           <Controls />
           <MiniMap
-            nodeColor={(n) => nodeColor((n.data as any)?.status ?? 'unknown', (n.data as any)?.role, showRepro)}
+            nodeColor={(n) => (n.type === 'bandNode'
+              ? 'transparent'
+              : nodeColor((n.data as any)?.status ?? 'unknown', (n.data as any)?.role, showRepro))}
             style={{ background: 'var(--dag-minimap)' }}
           />
           <Panel position="top-left">
-            <div className="dag-panel rounded-lg p-3 text-xs shadow-sm space-y-1.5">
+            {/* Folded by default. The key is a fixed block in the one corner the band labels
+                have to pass through, and at the zoom a seventy-claim graph fits at it covered
+                the thing the bands were added to show. The bar above the canvas now says what
+                the view is; this is the detail behind it. */}
+            <details className="dag-key">
+              <summary className="dag-panel">Key</summary>
+            <div className="dag-panel dag-keybody rounded-lg p-3 text-xs shadow-sm space-y-1.5">
               {/* The reproduction layer is a switch, and off by default. With it off the graph
                   shows what the paper argues and nothing about what we ran — which is the test
                   that the separation is real rather than described. */}
@@ -333,22 +541,27 @@ function DAGInner({ claims, paperSlug }: Props) {
               </div>
               {/* The edges carry as much of the argument as the nodes do, and had no key. */}
               <div className="border-t border-gray-200 dark:border-gray-700 pt-1.5 mt-1 space-y-1">
-                {(Object.keys(FAMILY) as Array<keyof typeof FAMILY>).map(k => (
-                  <div key={k} className="flex items-center gap-1.5">
+                {(mode === 'corpus'
+                  ? (Object.keys(FAMILY) as Array<keyof typeof FAMILY>).map(k => [FAMILY[k].stroke, FAMILY[k].dash, FAMILY[k].label] as const)
+                  : ([
+                      [MIRA_STROKE['mira:supports'], undefined, 'mira:supports'],
+                      [MIRA_STROKE['mira:opposes'], undefined, 'mira:opposes'],
+                    ] as const)
+                ).map(([stroke, dash, label]) => (
+                  <div key={label} className="flex items-center gap-1.5">
                     <svg width="22" height="8" style={{ display: 'inline-block', flexShrink: 0 }}>
                       <line x1="0" y1="4" x2="22" y2="4"
-                            stroke={FAMILY[k].stroke} strokeWidth="1.6"
-                            strokeDasharray={FAMILY[k].dash} />
+                            stroke={stroke} strokeWidth="1.6" strokeDasharray={dash} />
                     </svg>
-                    <span>{FAMILY[k].label}</span>
+                    <span>{label}</span>
                   </div>
                 ))}
               </div>
             </div>
+            </details>
           </Panel>
         </ReactFlow>
       </div>
-
     </div>
   );
 }

--- a/site/src/components/Reader.tsx
+++ b/site/src/components/Reader.tsx
@@ -16,6 +16,7 @@ type Claim = {
   statusLabel: string; plain: string; hasPlain: boolean; full: string;
   panel: string | null; panels: [string, string][]; method: string | null; dataset: string | null;
   check: { paper?: string; reproduced?: string; date?: string; how?: string } | null;
+  script: string | null; scriptSource: string | null;
   out: { rel: string; label: string; slug: string }[];
   in: { rel: string; label: string; slug: string }[];
 };
@@ -1241,7 +1242,21 @@ export default function Reader({ data, base }: Props) {
               <dl className="rd-cmp">
                 <dt>Paper says</dt><dd>{k.paper ?? '—'}</dd>
                 <dt>Our re-run</dt><dd>{k.reproduced ?? '—'}</dd>
+                {c.dataset && (
+                  <><dt>Data</dt><dd>{/^https?:/.test(c.dataset)
+                    ? <a href={c.dataset} target="_blank" rel="noopener">{c.dataset}</a>
+                    : c.dataset}</dd></>
+                )}
               </dl>
+            )}
+            {/* The check itself. A verdict a reader cannot audit is one they have to take on
+                trust; where a script was written, this is the script. Folded, because it is
+                the deepest thing on the card and not what most readers came for. */}
+            {c.scriptSource && (
+              <details className="rd-script">
+                <summary>The check we ran{c.script && <code>{c.script}</code>}</summary>
+                <pre>{c.scriptSource}</pre>
+              </details>
             )}
           </div>
         )}
@@ -1617,6 +1632,30 @@ export default function Reader({ data, base }: Props) {
         .rd-cmp { display: grid; grid-template-columns: 6em 1fr; gap: 0.15rem 0.7rem; font-size: 12.5px; margin: 0.4rem 0 0; }
         .rd-cmp dt { color: var(--card-muted); }
         .rd-cmp dd { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px; color: var(--card-head); overflow-wrap: anywhere; }
+        .rd-cmp dd a { color: var(--claim-strong); border-bottom: 1px solid var(--claim-line); }
+        /* The verification script, folded. The deepest thing on a claim card and the only
+           part of it a reader can check for themselves. */
+        .rd-script { margin: 0.6rem 0 0; }
+        .rd-script > summary {
+          list-style: none; cursor: pointer; font-size: 12px; color: var(--card-muted);
+          display: flex; align-items: baseline; gap: 0.45rem;
+        }
+        .rd-script > summary::-webkit-details-marker { display: none; }
+        .rd-script > summary::before {
+          content: ''; width: 5px; height: 5px; flex: none; transform: rotate(-45deg);
+          border-right: 1.5px solid var(--card-faint); border-bottom: 1.5px solid var(--card-faint);
+          transition: transform 0.15s;
+        }
+        .rd-script[open] > summary::before { transform: rotate(45deg); }
+        .rd-script > summary:hover { color: var(--claim-strong); }
+        .rd-script > summary code { font-size: 11px; color: var(--card-faint); }
+        .rd-script pre {
+          margin: 0.5rem 0 0; padding: 0.7rem 0.8rem; background: var(--card-sunk);
+          border: 1px solid var(--card-border); border-radius: 5px;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
+          line-height: 1.6; color: var(--card-body); overflow-x: auto; white-space: pre;
+          max-height: 22rem; overflow-y: auto;
+        }
         .rd-rel { margin: 0.3rem 0 0; padding: 0; list-style: none; }
         .rd-rel li { display: grid; grid-template-columns: 7.5em 1fr; gap: 0 0.6rem; align-items: baseline; padding: 0.4rem 0; border-top: 1px solid var(--card-border); font-size: 13px; line-height: 1.4; }
         .rd-rel li:first-child { border-top: 0; }

--- a/site/src/components/useFitOnReveal.ts
+++ b/site/src/components/useFitOnReveal.ts
@@ -9,25 +9,43 @@ import { useReactFlow } from 'reactflow';
  * the tab state keeps this independent of how the panel is hidden.
  *
  * Must be called inside a ReactFlowProvider. Attach the returned ref to the element that
- * wraps the ReactFlow canvas. */
-export function useFitOnReveal<T extends HTMLElement>(padding = 0.1) {
+ * wraps the ReactFlow canvas.
+ *
+ * `refitOnResize` keeps fitting while the box is still settling. The one-shot fit takes the
+ * first non-zero size it is offered, and on a page whose surrounding layout is still
+ * resolving that size is not the final one: the claim graph fitted at roughly half its
+ * eventual width and sat at 26% zoom in a pane that had room for 51%. Opt in where the
+ * container can change size after it appears; a reader who has zoomed or panned is left
+ * alone, because refitting under someone who has taken hold of the canvas is worse than a
+ * bad first fit. */
+export function useFitOnReveal<T extends HTMLElement>(
+  padding = 0.1,
+  { refitOnResize = false }: { refitOnResize?: boolean } = {},
+) {
   const ref = useRef<T>(null);
   const done = useRef(false);
+  const size = useRef('');
   const { fitView } = useReactFlow();
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+    let timer: ReturnType<typeof setTimeout>;
     const observer = new ResizeObserver(() => {
       if (done.current || !el.clientWidth || !el.clientHeight) return;
-      done.current = true;
+      const key = `${el.clientWidth}x${el.clientHeight}`;
+      if (key === size.current) return;
+      size.current = key;
+      if (!refitOnResize) done.current = true;
+      clearTimeout(timer);
       // After paint: fitView reads the viewport, which is not final in the same frame the
       // panel becomes visible.
-      requestAnimationFrame(() => fitView({ padding }));
+      timer = setTimeout(() => requestAnimationFrame(() => fitView({ padding })), refitOnResize ? 90 : 0);
     });
     observer.observe(el);
-    return () => observer.disconnect();
-  }, [fitView, padding]);
+    return () => { observer.disconnect(); clearTimeout(timer); };
+  }, [fitView, padding, refitOnResize]);
 
-  return ref;
+  // Call when the reader takes hold of the canvas, so no later resize yanks it back.
+  return Object.assign(ref, { settle: () => { done.current = true; } });
 }

--- a/site/src/lib/mira.ts
+++ b/site/src/lib/mira.ts
@@ -1,0 +1,46 @@
+// Which relation types a reader of core MIRA can actually interpret.
+//
+// The table is not written here, and must not be. corpus-facts.json carries
+// `mira_mapping.relations`, generated from scripts/export_mira.py — the exporter's own
+// declaration table — and `declared_under` on each row names the core MIRA predicate the
+// type is declared beneath. A row with `declared_under: null` is exported as a bare
+// `haak:reldef/<type>` hanging at AbstractRelationDef with no core parent.
+//
+// That distinction is the honest one, and it is narrower than "MIRA drops the edge". Every
+// paper's formats.json reports `mira.lost: 0` — the triples survive into the strict file.
+// What does not survive is their meaning: a consumer that knows only `mira:supports` and
+// `mira:opposes` reads a `haak:reldef/entails` triple and cannot tell whether it asserts
+// support, opposition, or something else entirely. The exporter's own counters call these
+// `neutral`, against `inherits_core` for the rest, and that is the split the graph's MIRA
+// view draws.
+import facts from '../data/corpus-facts.json';
+
+export type MiraParent = 'mira:supports' | 'mira:opposes' | null;
+
+interface MappingRow {
+  relation: string;
+  declared_under: MiraParent;
+  inverse_of: string | null;
+}
+
+const ROWS = ((facts as any).mira_mapping?.relations ?? []) as MappingRow[];
+
+/** The core MIRA predicate each relation type is declared beneath, or null for none. */
+export const MIRA_PARENT: Record<string, MiraParent> =
+  Object.fromEntries(ROWS.map(r => [r.relation, r.declared_under ?? null]));
+
+/** Types the exporter emits only as the inverse of another type — `derived-from` is the
+ *  inverse of `entails`, so it reaches MIRA only as an entails triple pointing the other
+ *  way, and entails itself declares no core parent. */
+export const MIRA_INVERSE_OF: Record<string, string | null> =
+  Object.fromEntries(ROWS.map(r => [r.relation, r.inverse_of ?? null]));
+
+/** True when a core-MIRA consumer can read this relation as support or opposition. */
+export function readableInCoreMira(rel: string): boolean {
+  return MIRA_PARENT[rel] === 'mira:supports' || MIRA_PARENT[rel] === 'mira:opposes';
+}
+
+/** The relation types this corpus uses that declare no core MIRA predicate, in the order
+ *  the exporter's table lists them. Derived, never typed out. */
+export const NO_CORE_PREDICATE: string[] =
+  ROWS.filter(r => !readableInCoreMira(r.relation)).map(r => r.relation);

--- a/site/src/lib/reader.ts
+++ b/site/src/lib/reader.ts
@@ -438,6 +438,12 @@ export function readerData(paperSlug: string) {
       method: c.method ?? null,
       dataset: c.dataset ?? null,
       check: checkOf(c),
+      // The re-run itself, where one was written. `script` is the path in the repo and
+      // `scriptSource` the text of it — 37 claims across the corpus carry both. A verdict a
+      // reader cannot audit is a verdict they have to take on trust, and this is the one
+      // place the page can hand them the actual check.
+      script: c.script ?? null,
+      scriptSource: c.scriptSource ?? null,
       out,
       in: inward,
     };

--- a/site/src/pages/papers/[paper].astro
+++ b/site/src/pages/papers/[paper].astro
@@ -84,7 +84,12 @@ const stage = stageLabel[(paperData as any).stage] || '';
       <details class="rec">
         <summary>The claim graph <span>{data.counts.claims} claims, and what rests on what</span></summary>
         <div class="rec-body">
-          <p>Solid edges are <code>requires</code>, dashed are <code>supports</code>. Clicking a node opens its card.</p>
+          <p>
+            Rows are what a claim does in the paper, so the deductive spine — a hypothesis, the
+            prediction it entails, the result that tests it — reads down the page. Clicking a node
+            opens its card and lights its ancestors and descendants. The format switch redraws the
+            graph as a reader of core MIRA sees it.
+          </p>
           <div class="dag"><ClaimDAG client:visible claims={paperData.claims} paperSlug={paperSlug} /></div>
         </div>
       </details>
@@ -185,5 +190,5 @@ const stage = stageLabel[(paperData as any).stage] || '';
   .rec-body { padding: 0.25rem 0 1.5rem; }
   .rec-body p { font-size: 13px; color: var(--card-muted); max-width: 64ch; margin: 0 0 0.9rem; line-height: 1.55; }
   .rec-body p a { color: var(--claim-strong); }
-  .dag { border: 1px solid var(--card-border); border-radius: 6px; overflow: hidden; height: 620px; }
+  .dag { border: 1px solid var(--card-border); border-radius: 6px; overflow: hidden; height: 760px; }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -479,6 +479,51 @@ html.dark {
   --dag-edge-framing: #a78bfa;
 }
 
+/* The format switch above the graph. The site's card tokens rather than the graph's own, so
+   the bar reads as part of the page chrome and the canvas below it as the figure. */
+.dag-formatbar {
+  flex: none;
+  border-bottom: 1px solid var(--card-border);
+  background: var(--card-bg);
+  padding: 0.55rem 0.75rem;
+}
+.dag-formatrow { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+.dag-seg { display: inline-flex; border: 1px solid var(--card-border); border-radius: 5px; overflow: hidden; flex: none; }
+.dag-seg button {
+  font-size: 12px; font-weight: 500; padding: 0.25rem 0.7rem;
+  background: transparent; color: var(--card-muted); border: 0; cursor: pointer;
+  font-family: inherit; line-height: 1.6;
+}
+.dag-seg button + button { border-left: 1px solid var(--card-border); }
+.dag-seg button:hover { color: var(--card-head); background: var(--card-bg-hover); }
+.dag-seg button[aria-pressed='true'] {
+  background: var(--claim-wash); color: var(--claim-strong); font-weight: 600;
+}
+.dag-formatnote { font-size: 12px; color: var(--card-muted); margin: 0; line-height: 1.5; min-width: 14rem; flex: 1; }
+.dag-formatnote strong { color: var(--card-head); font-weight: 600; }
+.dag-formatloss {
+  font-size: 11.5px; color: var(--card-muted); margin: 0.45rem 0 0;
+  line-height: 1.55; border-top: 1px dashed var(--card-border); padding-top: 0.45rem;
+}
+.dag-formatloss code { font-size: 11px; color: var(--card-strong); }
+
+/* The key, folded into a chip so it does not sit on top of the band labels. */
+.dag-key > summary {
+  list-style: none; cursor: pointer; font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  border-radius: 5px; padding: 0.25rem 0.6rem; display: inline-flex;
+  align-items: center; gap: 0.4rem; box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+.dag-key > summary::-webkit-details-marker { display: none; }
+.dag-key > summary::after {
+  content: ''; width: 5px; height: 5px; transform: rotate(45deg) translateY(-1px);
+  border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
+  opacity: 0.6; transition: transform 0.15s;
+}
+.dag-key[open] > summary::after { transform: rotate(-135deg) translateY(-1px); }
+.dag-key[open] > summary { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+.dag-key .dag-keybody { border-top-left-radius: 0; margin-top: -1px; }
+
 /* The layers that run a narrative step, injected under its heading on /method. */
 .method-prose .step-runs {
   font-size: 12.5px;


### PR DESCRIPTION
The graph drew all fourteen relation types and laid out with dagre, which cannot express role — correct and shapeless. Rebuilt against a reference design the user preferred, with one substantial departure from it.

## The format toggle, and why its claim is narrower than the reference's

A `This corpus / MIRA` switch above the canvas. In MIRA view every relation whose type declares no core MIRA predicate is removed and the rest flatten to two strokes; the banner names the types and counts. On Gädeke: 72 edges to 27, with the per-type counts summing to the 45 removed.

**The reference asserts MIRA *drops* those edges. This corpus says otherwise, and the view says what is true instead.** Every paper's `formats.json` reports `mira.lost: 0`. The triples survive into the strict file. What does not survive is their meaning: they export as bare `haak:reldef` terms with no parent, which the exporter's own counters call `neutral` — 53 of 79 on Gädeke, against 26 that inherit a core predicate. So the view is framed as what a reader of core MIRA can *interpret*, and the banner says the triples are in the file while nothing tells a consumer what they assert.

The type list is derived from `corpus-facts.json`, not hardcoded, and the banner's count comes off the edges actually drawn, so the number cannot disagree with the picture.

## Role bands

Six rows — hypotheses, predictions, findings, interpretation, controls and methods, scope and prior work — labelled in a gutter no edge crosses. dagre is kept for horizontal ordering only, refined by two barycentre sweeps; its ranks are discarded. Empty bands drop out, verified on a paper with no hypotheses, predictions or controls.

## Verification record

Added to the existing claim card rather than a new panel: data source and the verification script itself, folded.

## A bug found on the way

`useFitOnReveal` took the first non-zero size offered, which on this page was about half the eventual width, so the graph sat at 26% zoom in a pane with room for 51%. It re-fits while the box settles now, and stops when the reader takes hold.

## What is worse

- **The key is folded by default.** At the zoom a 71-claim graph fits at, it covered the band labels — the thing the redesign exists to show. One deliberate regression.
- The graph is taller, 620 to 760px.
- Labels are still small at overview zoom. 71 nodes at a readable size need more room than the container has; the model is shape-at-overview, zoom-to-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)