### PR TITLE
The three facts of a cell: mechanism, scheme, adjudication; and approve --declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ check:  ## Gates that are clean on main. A failure here is this change's fault.
 	cd extract && $(PYTHON) tests/test_profiles.py
 	cd extract && $(PYTHON) tests/test_evaluate_precision_and_edges.py
 	cd extract && $(PYTHON) tests/test_verdicts.py
+	$(PYTHON) scripts/test_pipeline_versions.py
 	$(PYTHON) scripts/audit_layers.py
 
 contract:  ## Regenerate the prompt contract from vocabulary.py, relations.py and schema.py

--- a/scripts/corpus_facts.py
+++ b/scripts/corpus_facts.py
@@ -331,6 +331,13 @@ def pipeline_state():
             "layers": decl["layers"],
             "groups": decl.get("groups") or {},
             "state": pipeline.state(decl),
+            # The scheme fact: per layer, whether its declaration is accepted, proposed or
+            # open, and which corpus-scope decisions a tree built now is still provisional on.
+            # Read here rather than in the site so the badge is fed the way every other one is.
+            "declarations": pipeline.declaration_state(decl),
+            # The adjudication fact: per paper, the verdict-file reading of each claim-tree
+            # version — how many claims and edges a reader considered, of how many.
+            "verdicts": _verdict_counts(),
             # The ledger itself, not only the latest state. A version history is the list of
             # runs, so the site can show one without a separate changelog to keep in step.
             "ledger": {p: pipeline.read_ledger(p) for p in pipeline.papers()},
@@ -338,6 +345,36 @@ def pipeline_state():
     except Exception as e:                                            # noqa: BLE001
         print(f"  warning: pipeline state unavailable — {e}")
         return None
+
+
+def _verdict_counts():
+    """Per paper, per claim-tree version, the reading recorded in its verdict file.
+
+    `runs/<paper>/claim-tree.v<N>.verdicts.jsonl` is what #110's tooling writes; the count of
+    verdicts a reader `considered`, of the total the skeleton pre-filled, is the "k of n" the
+    adjudication fact needs. Empty where no reading has begun, which is every paper today.
+    """
+    sys.path.insert(0, os.path.join(ROOT, "extract"))
+    from elife_extract import verdicts as vd
+    out = {}
+    for paper in sorted(os.listdir(os.path.join(ROOT, "runs"))
+                        if os.path.isdir(os.path.join(ROOT, "runs")) else []):
+        rd = os.path.join(ROOT, "runs", paper)
+        if not os.path.isdir(rd):
+            continue
+        vers = {}
+        for fn in sorted(os.listdir(rd)):
+            m = re.match(r"claim-tree\.v(\d+)\.verdicts\.jsonl$", fn)
+            if not m:
+                continue
+            res = vd.resolve(vd.load(os.path.join(rd, fn)))
+            vers[m.group(1)] = {
+                "considered": len(res.claims_considered()) + len(res.edges_considered()),
+                "total": len(res.claims) + len(res.edges),
+            }
+        if vers:
+            out[paper] = vers
+    return out
 
 
 def prediction_outcomes():

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -22,8 +22,9 @@ appends to one ledger in one shape, so staleness and propagation are computed on
     python3 scripts/pipeline.py run   <paper> <layer>   run it, and its unmet dependencies
     python3 scripts/pipeline.py run   <paper> <layer> --answer FILE   record an answer made elsewhere
     python3 scripts/pipeline.py approve <paper> <layer> --by NAME   record that someone read it
+    python3 scripts/pipeline.py approve --declaration <layer> --by NAME   rule on what it means
 
-Usage as a library: `load()`, `state()`.
+Usage as a library: `load()`, `state()`, `declaration_state()`.
 """
 
 from __future__ import annotations
@@ -368,6 +369,116 @@ def approve(paper: str, layer_id: str, v: int, *, by: str, note: str = "") -> di
     with open(p, "a", encoding="utf-8") as fh:
         fh.write(json.dumps(rec, sort_keys=True) + "\n")
     return rec
+
+
+# ── the scheme: a declaration, and the ruling on it ─────────────────────────────
+#
+# An adjudication is an operation on a *version* of one paper's output. A scheme ruling is the
+# other kind of decision (docs/design/2026-09-12-kinds-of-decision.md): a person accepts what a
+# layer *means*, for every paper, once. What is accepted is the declaration — the layers.yaml
+# entry plus the files that define its meaning: the prompt task file, and for a corpus-scope
+# vocabulary scripts/relations.py and the like — which is exactly what `reads` already names and
+# staleness already hashes. So a declaration version reuses `digest` rather than inventing a
+# second hash, and moves when the entry or one of those files does. The ruling lives in one
+# corpus-level ledger, in the same shape as a per-paper approval.
+
+ACCEPTED, PROPOSED = "accepted", "proposed"
+
+
+def corpus_approvals_path() -> str:
+    return os.path.join(ROOT, "runs", "approvals.jsonl")
+
+
+def read_corpus_approvals() -> list[dict]:
+    """Scheme rulings: a person's approval of a declaration version, corpus-wide."""
+    p = corpus_approvals_path()
+    if not os.path.isfile(p):
+        return []
+    out = []
+    with open(p, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def declaration_version(layer: dict) -> str:
+    """The hash of a layer's declaration: its entry, plus the files that define its meaning.
+
+    Those files are the layer's `reads` — the prompt task, the contract, the relation
+    vocabulary — the same paths a run hashes to go stale, so a ruling made under one wording is
+    a ruling under that wording and no other.
+    """
+    h = hashlib.sha256()
+    h.update(json.dumps(layer, sort_keys=True, default=str).encode("utf-8"))
+    for r in (layer.get("reads") or []):
+        h.update(f"{r}:{digest(r)}".encode("utf-8"))
+    return h.hexdigest()[:12]
+
+
+def approve_declaration(layer_id: str, version: str, *, by: str, note: str = "") -> dict:
+    """Record that a person accepted one version of one layer's declaration."""
+    rec = {"declaration": layer_id, "version": version, "by": by, "note": note,
+           "when": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}
+    p = corpus_approvals_path()
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    return rec
+
+
+def declaration_state(decl: dict | None = None) -> dict:
+    """Per layer, the scheme its declaration is in.
+
+    `accepted` when a ruling names the current declaration version; `proposed` when the
+    declaration has moved past the accepted one, or the entry itself says `status: proposed`
+    and nothing is accepted; `open` otherwise. `provisional_on` lists the corpus-scope
+    declarations a layer needs that are not accepted — a tree built while `relation-vocab` is
+    open is provisional on its own cell, and this is what says which decision it waits on.
+    """
+    decl = decl or load()
+    by_id = decl["by_id"]
+    latest: dict[str, dict] = {}
+    for a in read_corpus_approvals():
+        lid = a.get("declaration")
+        if not lid:
+            continue
+        if lid not in latest or a.get("when", "") >= latest[lid].get("when", ""):
+            latest[lid] = a
+
+    out: dict[str, dict] = {}
+    for lid, layer in by_id.items():
+        ver = declaration_version(layer)
+        ok = latest.get(lid)
+        if ok and ok.get("version") == ver:
+            out[lid] = {"scheme": ACCEPTED, "version": ver,
+                        "approved": {"version": ver, "by": ok.get("by"),
+                                     "when": ok.get("when"), "note": ok.get("note")}}
+        elif ok:
+            out[lid] = {"scheme": PROPOSED, "version": ver,
+                        "approved": {"version": ok.get("version"), "by": ok.get("by"),
+                                     "when": ok.get("when"), "note": ok.get("note"),
+                                     "superseded": True}}
+        elif layer.get("status") == PROPOSED:
+            out[lid] = {"scheme": PROPOSED, "version": ver}
+        else:
+            out[lid] = {"scheme": OPEN, "version": ver}
+
+    def corpus_deps(lid: str, seen: set[str] | None = None) -> set[str]:
+        seen = seen if seen is not None else set()
+        for d in by_id[lid].get("needs") or []:
+            if d not in seen:
+                seen.add(d)
+                corpus_deps(d, seen)
+        return seen
+
+    for lid in by_id:
+        waits = sorted(d for d in corpus_deps(lid)
+                       if by_id[d].get("scope") == "corpus" and out[d]["scheme"] != ACCEPTED)
+        if waits:
+            out[lid]["provisional_on"] = waits
+    return out
 
 
 def state(decl: dict | None = None, slugs: list[str] | None = None) -> dict:
@@ -827,7 +938,16 @@ def cmd_approve(args) -> int:
     approving a version that is not the one on disk is almost always a mistake — but it can
     be named explicitly, since reading v2 and recording it after v3 has run is a coherent
     thing to have done.
+
+    With `--declaration` it is the other kind of decision: a scheme ruling on what a layer
+    means, recorded against the declaration's version in the corpus-level ledger.
     """
+    if args.declaration:
+        return cmd_approve_declaration(args)
+    if not args.paper or not args.layer:
+        print("error: approve needs <paper> <layer>, or --declaration <layer>",
+              file=sys.stderr)
+        return 2
     decl = load()
     if args.layer not in decl["by_id"]:
         print(f"error: no layer {args.layer!r}", file=sys.stderr)
@@ -851,6 +971,25 @@ def cmd_approve(args) -> int:
     current = " (the current version)" if v == run["v"] else \
               f" (superseded — the ledger is at v{run['v']})"
     print(f"{args.paper}/{args.layer} v{v} approved by {rec['by']}{current}")
+    if rec["note"]:
+        print(f"  {rec['note']}")
+    return 0
+
+
+def cmd_approve_declaration(args) -> int:
+    """Record a scheme ruling: a person accepts what a layer means, for every paper."""
+    decl = load()
+    lid = args.declaration
+    if lid not in decl["by_id"]:
+        print(f"error: no layer {lid!r}", file=sys.stderr)
+        return 2
+    ver = declaration_version(decl["by_id"][lid])
+    was = declaration_state(decl)[lid]
+    if was["scheme"] == ACCEPTED:
+        print(f"{lid}: declaration {ver} is already accepted by {was['approved']['by']} — "
+              f"recording another ruling on the same version")
+    rec = approve_declaration(lid, ver, by=args.by, note=args.note or "")
+    print(f"{lid} declaration {ver} accepted by {rec['by']}")
     if rec["note"]:
         print(f"  {rec['note']}")
     return 0
@@ -893,10 +1032,12 @@ def main() -> int:
     r.add_argument("--profile", help="model profile to pass through to each layer command "
                    "(frontier, standard, open, subagent). The ledger's `by` records it.")
     r.set_defaults(fn=cmd_run)
-    a = sub.add_parser("approve", help="record that a person approved one version of a layer")
-    a.add_argument("paper")
-    a.add_argument("layer")
-    a.add_argument("--by", required=True, help="who read it")
+    a = sub.add_parser("approve", help="approve one paper's output, or a layer's declaration")
+    a.add_argument("paper", nargs="?", help="the paper (omit with --declaration)")
+    a.add_argument("layer", nargs="?", help="the layer (omit with --declaration)")
+    a.add_argument("--declaration", metavar="LAYER",
+                   help="record a scheme ruling on this layer's declaration instead")
+    a.add_argument("--by", required=True, help="who decided")
     a.add_argument("--v", type=int, help="which version (default: the one on the ledger)")
     a.add_argument("--note", help="what they checked")
     a.set_defaults(fn=cmd_approve)

--- a/scripts/test_pipeline_versions.py
+++ b/scripts/test_pipeline_versions.py
@@ -54,6 +54,107 @@ def test_keep_versions_copies_runs_single_files():
         assert (root / "runs/p/reconciler.output.json").is_file()
 
 
+def _decl(root: Path):
+    """A tiny two-layer declaration under `root`, with its reads on disk, loaded with
+    pipeline pointed at `root` so digests and the corpus ledger resolve there."""
+    _touch(root, "scripts/relations.py", "EDGE_KEYS = ['supports']\n")
+    (root / "pipeline").mkdir(parents=True, exist_ok=True)
+    (root / "pipeline" / "layers.yaml").write_text(
+        "version: 1\n"
+        "layers:\n"
+        "  - id: claim-format\n"
+        "    kind: feature\n"
+        "    scope: corpus\n"
+        "    reads: []\n"
+        "  - id: relation-vocab\n"
+        "    kind: question\n"
+        "    scope: corpus\n"
+        "    needs: [claim-format]\n"
+        "    reads: [scripts/relations.py]\n"
+        "  - id: claim-tree\n"
+        "    kind: step\n"
+        "    scope: paper\n"
+        "    needs: [relation-vocab]\n"
+        "    produces: ['claims/{paper}/*.md']\n",
+        encoding="utf-8")
+    pipeline.ROOT = str(root)
+    return pipeline.load(str(root / "pipeline" / "layers.yaml"))
+
+
+def test_declaration_version_is_a_function_of_entry_and_reads():
+    old = pipeline.ROOT
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            decl = _decl(root)
+            rv = decl["by_id"]["relation-vocab"]
+            v1 = pipeline.declaration_version(rv)
+            assert v1 == pipeline.declaration_version(rv)          # deterministic
+            # A read file it names moves the version — the same machinery staleness uses.
+            _touch(root, "scripts/relations.py", "EDGE_KEYS = ['supports', 'tests']\n")
+            assert pipeline.declaration_version(rv) != v1
+    finally:
+        pipeline.ROOT = old
+
+
+def test_declaration_state_open_accepted_superseded():
+    old = pipeline.ROOT
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            decl = _decl(root)
+            rv = decl["by_id"]["relation-vocab"]
+
+            # Never approved → open, and claim-tree is provisional on the corpus decisions.
+            ds = pipeline.declaration_state(decl)
+            assert ds["relation-vocab"]["scheme"] == "open"
+            assert ds["claim-tree"].get("provisional_on") == ["claim-format", "relation-vocab"]
+
+            # Approve claim-format and the current relation-vocab version → accepted.
+            pipeline.approve_declaration("claim-format",
+                                         pipeline.declaration_version(decl["by_id"]["claim-format"]),
+                                         by="curator")
+            ver = pipeline.declaration_version(rv)
+            pipeline.approve_declaration("relation-vocab", ver, by="curator", note="ruled")
+            ds = pipeline.declaration_state(decl)
+            assert ds["relation-vocab"]["scheme"] == "accepted"
+            assert ds["relation-vocab"]["approved"]["by"] == "curator"
+            # claim-tree now waits on nothing — both corpus deps are accepted.
+            assert "provisional_on" not in ds["claim-tree"]
+
+            # Move the declaration past what was accepted → proposed, marked superseded.
+            _touch(root, "scripts/relations.py", "EDGE_KEYS = ['supports', 'opposes']\n")
+            ds = pipeline.declaration_state(decl)
+            assert ds["relation-vocab"]["scheme"] == "proposed"
+            assert ds["relation-vocab"]["approved"]["superseded"] is True
+            # And claim-tree is provisional again, on relation-vocab alone.
+            assert ds["claim-tree"].get("provisional_on") == ["relation-vocab"]
+
+            # The ruling is one line in the corpus-level ledger, in the approval shape.
+            recs = pipeline.read_corpus_approvals()
+            assert [r["declaration"] for r in recs] == ["claim-format", "relation-vocab"]
+            assert recs[1]["version"] == ver and recs[1]["note"] == "ruled"
+    finally:
+        pipeline.ROOT = old
+
+
+def test_status_proposed_reads_as_proposed_until_accepted():
+    old = pipeline.ROOT
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            decl = _decl(root)
+            decl["by_id"]["relation-vocab"]["status"] = "proposed"
+            ds = pipeline.declaration_state(decl)
+            assert ds["relation-vocab"]["scheme"] == "proposed"
+            pipeline.approve_declaration("relation-vocab",
+                                         pipeline.declaration_version(decl["by_id"]["relation-vocab"]),
+                                         by="curator")
+            assert pipeline.declaration_state(decl)["relation-vocab"]["scheme"] == "accepted"
+    finally:
+        pipeline.ROOT = old
+
+
 def test_keep_versions_ignores_non_runs_globs_and_missing():
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)

--- a/site/src/components/LayerHeader.astro
+++ b/site/src/components/LayerHeader.astro
@@ -6,7 +6,8 @@
 // own — MIRA has schema requirements no generic view can generate — and those pages should
 // carry the same head as the rest rather than reinventing it. A bespoke page is depth behind
 // the general surface, not an escape from it.
-import { byId, groups, dependents, resolve, type LayerDecl } from '../lib/pipeline';
+import { byId, groups, dependents, resolve, scheme, adjudicatedCount,
+         SCHEME_LABEL, SCHEME_NOTE, papers, type LayerDecl } from '../lib/pipeline';
 
 interface Props { layer: LayerDecl }
 const { layer } = Astro.props;
@@ -15,6 +16,17 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const url = (p: string) => `${base}${p}/`;
 const feeds = dependents(layer.id);
 const needs = (layer.needs ?? []).map(n => byId[n]).filter(Boolean);
+
+// The scheme fact: what this layer's declaration means, and who ruled on it. The counter
+// beside it is how many papers a person has read under the layer — a scheme is accepted for
+// every paper at once, so the two belong together.
+const sch = scheme(layer.id);
+const read = adjudicatedCount(layer.id);
+const SCHEME_TONE: Record<string, string> = {
+  accepted: 'border-emerald-500 text-emerald-700 dark:text-emerald-400',
+  proposed: 'border-dashed border-amber-500 text-amber-700 dark:text-amber-400',
+  open: 'border-blue-400 text-blue-700 dark:text-blue-400',
+};
 
 const KIND_NOTE: Record<string, string> = {
   step: 'Mechanical: re-runnable from its declared inputs.',
@@ -43,13 +55,25 @@ const paras = (s: string) =>
   <div class="flex flex-wrap items-baseline gap-3 mb-2">
     <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0">{layer.title}</h1>
     <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{layer.kind} · {layer.scope}</span>
-    {layer.status === 'proposed' && (
-      <span class="text-xs font-mono uppercase tracking-wider px-1.5 py-0.5 rounded border border-dashed border-amber-500 text-amber-700 dark:text-amber-400"
-            title="This layer's declaration is a proposal. It runs, but nothing about it has been accepted.">provisional</span>
+    {sch && (
+      <span class={`text-xs font-mono uppercase tracking-wider px-1.5 py-0.5 rounded border ${SCHEME_TONE[sch.state]}`}
+            title={SCHEME_NOTE[sch.state]}>{SCHEME_LABEL[sch.state]}</span>
     )}
-    {layer.open && <span class="text-xs font-mono uppercase tracking-wider text-blue-700 dark:text-blue-400">undecided</span>}
     {layer.requires_human && <span class="text-xs font-mono uppercase tracking-wider text-amber-700 dark:text-amber-400">needs a person</span>}
   </div>
+  {sch && (
+    <p class="text-sm text-gray-500 dark:text-gray-400 m-0 mb-2">
+      {sch.state === 'accepted' && sch.approved ? (
+        <span>Declaration <span class="font-mono text-xs">{sch.version}</span> accepted by {sch.approved.by}{sch.approved.when ? ` on ${sch.approved.when.slice(0, 10)}` : ''}.</span>
+      ) : sch.approved?.superseded ? (
+        <span>An earlier declaration was accepted by {sch.approved.by}; it has moved since — this is <span class="font-mono text-xs">{sch.version}</span>, unaccepted.</span>
+      ) : (
+        <span>Declaration <span class="font-mono text-xs">{sch.version}</span> has not been accepted by anyone.</span>
+      )}
+      <span class="mx-1">·</span>
+      {read === 0 ? 'no paper read under it' : `${read} of ${papers.length} papers read under it`}
+    </p>
+  )}
   <p class="text-lg text-gray-700 dark:text-gray-300 italic m-0 mb-3 leading-snug">{layer.question}</p>
   <p class="text-sm text-gray-600 dark:text-gray-400 m-0">{KIND_NOTE[layer.kind]}</p>
   {layer.group && groups[layer.group] && (

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -519,6 +519,238 @@
   "papers_without_verify_audit": 6,
   "parts": 16,
   "pipeline": {
+    "declarations": {
+      "abstract-map": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "9105a6599f94"
+      },
+      "adjudication": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "b59e206967dd"
+      },
+      "article": {
+        "scheme": "open",
+        "version": "9a6da6671d95"
+      },
+      "caption-reader": {
+        "scheme": "open",
+        "version": "c0107b7ab4f4"
+      },
+      "claim-format": {
+        "scheme": "open",
+        "version": "98a231dab03d"
+      },
+      "claim-tree": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "118407e3a404"
+      },
+      "coverage": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "2f67caa45995"
+      },
+      "dg-export": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "2f1ef256c69e"
+      },
+      "edge-inference": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "81f1975bfe7b"
+      },
+      "edge-review": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "8be601c18783"
+      },
+      "epistemic-vocab": {
+        "provisional_on": [
+          "claim-format"
+        ],
+        "scheme": "open",
+        "version": "e8c922b42026"
+      },
+      "evaluation": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "a793c79953a6"
+      },
+      "external-review": {
+        "scheme": "open",
+        "version": "362f90c207c7"
+      },
+      "formats-report": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "cb89e2debea6"
+      },
+      "gap-claim": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "fa9fde472418"
+      },
+      "marks": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "04d948bbcc42"
+      },
+      "mira-export": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "8b606d39e018"
+      },
+      "oxa-export": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "5892f1a603f0"
+      },
+      "parts": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "794eaf222bf9"
+      },
+      "plain-claim": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "d1e157e966d1"
+      },
+      "prediction-outcome": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "proposed",
+        "version": "bc17a8fcae67"
+      },
+      "prepare": {
+        "scheme": "open",
+        "version": "4c628a1359cf"
+      },
+      "questions": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "f33ce25ab8a3"
+      },
+      "reconcile": {
+        "scheme": "open",
+        "version": "9207098801ff"
+      },
+      "reference-check": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "8878c73a99f5"
+      },
+      "relation-vocab": {
+        "provisional_on": [
+          "claim-format"
+        ],
+        "scheme": "open",
+        "version": "cdfdc9f9e37b"
+      },
+      "replication": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "a736d33bdd51"
+      },
+      "results-reader": {
+        "scheme": "open",
+        "version": "763a948019a9"
+      },
+      "stance": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "5870f19ed940"
+      },
+      "structure-reader": {
+        "scheme": "open",
+        "version": "e0034c45b656"
+      },
+      "summaries": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "8a2c9d9a5fc1"
+      },
+      "synthesis": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "9eefcaa6626d"
+      },
+      "verification": {
+        "provisional_on": [
+          "claim-format",
+          "relation-vocab"
+        ],
+        "scheme": "open",
+        "version": "669700b9bef6"
+      }
+    },
     "groups": {
       "induction": {
         "question": "What did the readers find, and what survived reconciliation?",
@@ -31270,7 +31502,8 @@
           "v": 1
         }
       }
-    }
+    },
+    "verdicts": {}
   },
   "prediction_outcome": {
     "abstained": 6,

--- a/site/src/lib/pipeline.ts
+++ b/site/src/lib/pipeline.ts
@@ -16,6 +16,35 @@ import corpus from '../data/claims.json';
 export type CellState =
   | 'current' | 'stale' | 'absent' | 'blocked' | 'n/a' | 'open' | 'unrecorded';
 
+/** The scheme fact: what a layer's declaration means, for every paper. `accepted` when a
+ *  person has ruled on the current declaration version; `proposed` when the declaration has
+ *  moved past what was accepted, or its entry says so and nothing is accepted; `open`
+ *  otherwise. Computed by pipeline.py, read from corpus-facts.json. */
+export type SchemeState = 'accepted' | 'proposed' | 'open';
+
+export interface Scheme {
+  state: SchemeState;
+  /** The declaration's version hash — its entry plus the files that define its meaning. */
+  version: string;
+  /** The ruling that stands, if any. `superseded` is set when it named an earlier version. */
+  approved?: { version: string; by?: string; when?: string; note?: string; superseded?: boolean };
+  /** Corpus-scope declarations this layer needs that are not accepted. A tree built while one
+   *  is open is provisional on its own cell — this is which decision it waits on. */
+  provisionalOn?: string[];
+}
+
+/** The adjudication fact: whether a person has read this cell's output. From the per-paper
+ *  approvals ledger and the verdict file the reading is recorded in. */
+export interface Adjudication {
+  kind: 'approved' | 'partial' | 'superseded' | 'unread';
+  v?: number;
+  by?: string;
+  when?: string;
+  /** For a partial reading: verdicts considered, of the total the skeleton pre-filled. */
+  considered?: number;
+  total?: number;
+}
+
 export interface LayerDecl {
   id: string;
   title: string;
@@ -79,6 +108,11 @@ export interface Cell {
   /** Approval is an operation on a version, not a layer. `applies` is false when the layer
    *  has run again since — the approval was granted to output that no longer exists. */
   approved?: { v: number; by?: string; when?: string; note?: string; applies: boolean };
+  /** The three facts a cell carries. `state` above is the mechanism; these are the other two.
+   *  Scheme is the layer's declaration status (plus what it is provisional on); adjudication
+   *  is whether a person has read this version. */
+  scheme?: Scheme;
+  adjudication: Adjudication;
   /** Addresses. */
   href: string;
   dataHref: string;
@@ -107,6 +141,34 @@ export const corpusLayers = layers.filter(l => l.scope === 'corpus');
 
 export const papers: string[] = Object.keys(P?.state ?? {}).sort();
 const LEDGER: Record<string, any[]> = P?.ledger ?? {};
+const DECLS: Record<string, any> = P?.declarations ?? {};
+const VERDICTS: Record<string, Record<string, { considered: number; total: number }>> =
+  P?.verdicts ?? {};
+
+/** A layer's scheme, or null when the declaration state was not computed. */
+export function scheme(layerId: string): Scheme | null {
+  const d = DECLS[layerId];
+  if (!d) return null;
+  return {
+    state: d.scheme, version: d.version, approved: d.approved,
+    provisionalOn: d.provisional_on?.length ? d.provisional_on : undefined,
+  };
+}
+
+/** The adjudication fact for a cell: what a person has read of this version. */
+function adjudicationOf(paper: string, layerId: string,
+                        v: number | undefined, approved: Cell['approved']): Adjudication {
+  const vinfo = v != null ? VERDICTS[paper]?.[String(v)] : undefined;
+  const partial = vinfo ? { considered: vinfo.considered, total: vinfo.total } : {};
+  if (approved?.applies) {
+    const incomplete = vinfo && vinfo.considered < vinfo.total;
+    return { kind: incomplete ? 'partial' : 'approved',
+             v: approved.v, by: approved.by, when: approved.when, ...partial };
+  }
+  if (approved) return { kind: 'superseded', v: approved.v, by: approved.by, when: approved.when };
+  if (vinfo && vinfo.considered > 0) return { kind: 'partial', v, ...partial };
+  return { kind: 'unread' };
+}
 
 /** A paper's version history: every run, newest first. This is the changelog — there is no
  *  second one to keep in step with it. */
@@ -161,6 +223,8 @@ export function cell(paper: string, layerId: string): Cell | null {
     backfilled: raw.backfilled,
     versions: history(paper, layerId),
     approved: raw.approved,
+    scheme: scheme(layerId) ?? undefined,
+    adjudication: adjudicationOf(paper, layerId, raw.v, raw.approved),
     produces: (layer.produces ?? []).map(p => fill(p, paper)),
     command: layer.command ? fill(layer.command, paper) : undefined,
     href: `${base}/papers/${paper}/${layerId}/`,
@@ -275,6 +339,16 @@ export function approvedCells(): Cell[] {
   return papers.flatMap(p => cells(p).filter(c => c.approved?.applies));
 }
 
+/** How many papers a person has read under this layer — the adjudication counter a layer page
+ *  carries beside its scheme badge. Counts approved and partial readings; superseded and
+ *  unread are not readings that still stand. */
+export function adjudicatedCount(layerId: string): number {
+  return papers.filter(p => {
+    const c = cell(p, layerId);
+    return c && (c.adjudication.kind === 'approved' || c.adjudication.kind === 'partial');
+  }).length;
+}
+
 /** What each declared view is, and where it is rendered.
  *
  *  `views` was a list of words printed on the page and implemented nowhere, which reads as a
@@ -318,3 +392,31 @@ export const STATE_NOTE: Record<CellState, string> = {
   open: 'The layer is a question nobody has answered yet.',
   unrecorded: 'The file exists; no run was observed, so nothing can say whether it is current.',
 };
+
+// ── the other two facts, in words ────────────────────────────────────────────
+// Mechanism is the cell's colour, above. Scheme is the layer's declaration; adjudication is
+// whether a person has read this version. Three facts, three vocabularies, told apart so a
+// single word cannot pretend to be all three — see docs/design/2026-09-12-kinds-of-decision.md.
+
+export const SCHEME_LABEL: Record<SchemeState, string> = {
+  accepted: 'accepted', proposed: 'proposed', open: 'open',
+};
+
+export const SCHEME_NOTE: Record<SchemeState, string> = {
+  accepted: 'A person ruled on what this layer means, for the declaration as it stands now.',
+  proposed: 'The rule exists and runs, but nothing has been accepted — or the declaration has moved since it was.',
+  open: 'What this layer means is undecided. Everything built under it is provisional.',
+};
+
+export const ADJUDICATION_LABEL: Record<Adjudication['kind'], string> = {
+  approved: 'approved', partial: 'partial', superseded: 'superseded', unread: 'unread',
+};
+
+/** The adjudication fact as one line — the "approved v3 by X", "partial, 4 of 30", the rest. */
+export function adjudicationText(a: Adjudication): string {
+  if (a.kind === 'approved') return `approved v${a.v}${a.by ? ` by ${a.by}` : ''}`;
+  if (a.kind === 'partial')
+    return a.considered != null ? `partial — ${a.considered} of ${a.total} considered` : 'partial reading';
+  if (a.kind === 'superseded') return `v${a.v} approved, then the layer ran again`;
+  return 'unread';
+}

--- a/site/src/pages/papers/[paper]/[layer].astro
+++ b/site/src/pages/papers/[paper]/[layer].astro
@@ -13,7 +13,8 @@ import LayerComparison from '../../../components/LayerComparison.astro';
 import AbstractAlignment from '../../../components/AbstractAlignment.astro';
 import ArgumentFromGraph from '../../../components/ArgumentFromGraph.astro';
 import { getCollection, render } from 'astro:content';
-import { paperLayers, byId, cell, STATE_LABEL } from '../../../lib/pipeline';
+import { paperLayers, byId, cell, STATE_LABEL, SCHEME_LABEL, SCHEME_NOTE,
+         ADJUDICATION_LABEL, adjudicationText } from '../../../lib/pipeline';
 import { artifacts, isDirectory } from '../../../lib/artifacts';
 import { layerVersions, evaluation } from '../../../lib/layer-source';
 import corpus from '../../../data/claims.json';
@@ -112,6 +113,24 @@ const TONE: Record<string, string> = {
   open: 'text-blue-700 dark:text-blue-400 border-blue-400',
   unrecorded: 'text-gray-500 dark:text-gray-400 border-gray-300 dark:border-gray-700',
 };
+
+// The three facts, each its own chip. Mechanism is the state above; scheme is the layer's
+// declaration, provisional where a corpus decision it needs is still open; adjudication is
+// whether a person has read this version. A cell used to fold all three into the one state
+// word — see docs/design/2026-09-12-kinds-of-decision.md.
+const provisional = c.scheme?.provisionalOn?.length && layer.scope !== 'corpus'
+  ? c.scheme.provisionalOn : null;
+const SCHEME_TONE: Record<string, string> = {
+  accepted: 'text-emerald-700 dark:text-emerald-400 border-emerald-500',
+  proposed: 'text-amber-700 dark:text-amber-400 border-dashed border-amber-500',
+  open: 'text-blue-700 dark:text-blue-400 border-blue-400',
+};
+const ADJ_TONE: Record<string, string> = {
+  approved: 'text-emerald-700 dark:text-emerald-400 border-emerald-500',
+  partial: 'text-amber-700 dark:text-amber-400 border-amber-500',
+  superseded: 'text-gray-500 dark:text-gray-400 border-gray-300 dark:border-gray-700',
+  unread: 'text-gray-500 dark:text-gray-400 border-gray-300 dark:border-gray-700',
+};
 ---
 
 <Layout title={`${layer.title} — ${paper.slug}`} description={`${layer.question} — for ${paper.title}`}>
@@ -125,10 +144,24 @@ const TONE: Record<string, string> = {
     </nav>
 
     <header class="mb-8">
-      <div class="flex flex-wrap items-baseline gap-3 mb-2">
-        <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0">{layer.title}</h1>
-        <span class={`font-mono text-xs px-2 py-0.5 rounded border ${TONE[c.state]}`}>
+      <div class="flex flex-wrap items-baseline gap-2 mb-2">
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight m-0 mr-1">{layer.title}</h1>
+        {/* Mechanism — the cell's colour elsewhere, its own chip here. */}
+        <span class={`font-mono text-xs px-2 py-0.5 rounded border ${TONE[c.state]}`}
+              title={`mechanism — ${STATE_LABEL[c.state]}`}>
           {STATE_LABEL[c.state]}{c.v ? ` · v${c.v}` : ''}
+        </span>
+        {/* Scheme — the declaration, provisional where a corpus decision it needs is open. */}
+        {c.scheme && (
+          <span class={`font-mono text-xs px-2 py-0.5 rounded border ${SCHEME_TONE[c.scheme.state]}`}
+                title={`scheme — ${SCHEME_NOTE[c.scheme.state]}`}>
+            {provisional ? 'provisional' : SCHEME_LABEL[c.scheme.state]}
+          </span>
+        )}
+        {/* Adjudication — whether a person has read this version. */}
+        <span class={`font-mono text-xs px-2 py-0.5 rounded border ${ADJ_TONE[c.adjudication.kind]}`}
+              title="adjudication — whether a person has read this version">
+          {adjudicationText(c.adjudication)}
         </span>
       </div>
       <p class="text-gray-700 dark:text-gray-300 italic m-0 mb-2 leading-snug">{layer.question}</p>
@@ -140,6 +173,19 @@ const TONE: Record<string, string> = {
         <a href={c.dataHref} class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">json</a>
       </p>
     </header>
+
+    {provisional && (
+      <div class="border border-blue-300 dark:border-blue-800 rounded-lg p-4 mb-8">
+        <h2 class="text-sm font-semibold text-gray-900 dark:text-gray-100 m-0 mb-1.5">Provisional</h2>
+        <p class="text-sm text-gray-700 dark:text-gray-300 m-0">
+          This layer needs a corpus-scope decision that no one has accepted, so what it
+          produces would change if the decision changed. It waits on
+          {provisional.map((d: string, i: number) => (
+            <span>{i > 0 ? ', ' : ' '}<a href={url(`/pipeline/${d}`)} class="font-mono text-xs text-amber-700 dark:text-amber-400 no-underline hover:underline">{d}</a></span>
+          ))}.
+        </p>
+      </div>
+    )}
 
     <div class={`border rounded-lg p-4 mb-8 ${c.approved?.applies
         ? 'border-emerald-400 dark:border-emerald-700' : 'border-gray-200 dark:border-gray-700'}`}>
@@ -155,6 +201,12 @@ const TONE: Record<string, string> = {
         <p class="text-sm text-gray-700 dark:text-gray-300 m-0">
           v{c.approved.v} was approved by {c.approved.by}, and this layer has run since. An
           approval names the version it was given to; it does not follow the layer forward.
+        </p>
+      ) : c.adjudication.kind === 'partial' ? (
+        <p class="text-sm text-gray-700 dark:text-gray-300 m-0">
+          A reading is under way — {adjudicationText(c.adjudication)} — and has not been
+          approved. A partial reading is a legitimate state; the counts come from the
+          version's verdict file.
         </p>
       ) : (
         <p class="text-sm text-gray-700 dark:text-gray-300 m-0">

--- a/site/src/pages/pipeline/index.astro
+++ b/site/src/pages/pipeline/index.astro
@@ -8,7 +8,8 @@ import PipelineExplorer from '../../components/PipelineExplorer';
 import { corpusExplorer } from '../../lib/explorer';
 import {
   layers, groups, papers, cells, titleOf, fill_of, inState, byId,
-  corpusLayers, paperLayers, STATE_LABEL, allHistory, shortOf,
+  corpusLayers, paperLayers, STATE_LABEL, SCHEME_LABEL, ADJUDICATION_LABEL,
+  adjudicationText, allHistory, shortOf, type Cell,
 } from '../../lib/pipeline';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -31,6 +32,21 @@ const TONE: Record<string, string> = {
   unrecorded: 'bg-gray-300 dark:bg-gray-600',
 };
 const totalCells = papers.reduce((n, p) => n + cells(p).length, 0);
+
+// The three facts, folded into one hover: mechanism (the colour), scheme (the declaration),
+// adjudication (whether a person has read this version). The mark below carries adjudication
+// at a glance; the title carries all three for a reader who stops on a cell.
+const cellTitle = (c: Cell) => {
+  const parts = [`${c.layer.title} — ${STATE_LABEL[c.state]}${c.v ? ` v${c.v}` : ''}`];
+  if (c.scheme) parts.push(`scheme: ${SCHEME_LABEL[c.scheme.state]}${
+    c.scheme.provisionalOn && c.layer.scope !== 'corpus' ? ' (provisional)' : ''}`);
+  parts.push(`read: ${adjudicationText(c.adjudication)}`);
+  return parts.join(' · ');
+};
+// How many papers a person has read, at all, across the corpus — the fact the mark makes
+// visible at this altitude, and which has never been shown here before.
+const adjudicated = papers.reduce(
+  (n, p) => n + cells(p).filter(c => c.adjudication.kind !== 'unread').length, 0);
 
 // The matrix columns run in layer order, which is phase order, so a layer's group is a
 // contiguous span of columns. Grouping the rotated labels under a phase header turns
@@ -66,7 +82,9 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       </p>
       <p class="text-gray-600 dark:text-gray-400 mt-3 m-0 leading-relaxed">
         {papers.length} papers, {paperLayers.length} layers each. {(counts.current ?? 0) + (counts.unrecorded ?? 0)} of
-        the {totalCells} cells hold an answer. None of them has been read and approved by a person.
+        the {totalCells} cells hold an answer. {adjudicated === 0
+          ? 'None of them has been read by a person.'
+          : `${adjudicated} ${adjudicated === 1 ? 'has' : 'have'} been read by a person.`}
       </p>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 m-0">
         <a href={url('/method')} class="text-amber-700 dark:text-amber-400 no-underline hover:underline">How a paper is taken apart</a>,
@@ -141,8 +159,18 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
                 {cells(p).map((c, i) => (
                   <td class={`py-1.5 px-1 text-center${edge(i)}`}>
                     <a href={`#layer=${c.layer.id}`}
-                       title={`${c.layer.title} — ${STATE_LABEL[c.state]}${c.v ? ` (v${c.v})` : ''}`}
-                       class={`inline-block w-3.5 h-3.5 rounded-sm ${TONE[c.state] ?? TONE.absent}`}></a>
+                       title={cellTitle(c)}
+                       class={`relative inline-block w-3.5 h-3.5 rounded-sm ${TONE[c.state] ?? TONE.absent}`}>
+                      {/* Adjudication as a mark over the mechanism colour: a filled dot where a
+                          person has approved this version, a ring where the reading is partial.
+                          Nothing where nobody has read it — which is every cell today. */}
+                      {c.adjudication.kind === 'approved' && (
+                        <i class="absolute inset-0 m-auto w-1.5 h-1.5 rounded-full bg-white dark:bg-gray-950 ring-1 ring-gray-900/40"></i>
+                      )}
+                      {c.adjudication.kind === 'partial' && (
+                        <i class="absolute inset-0 m-auto w-1.5 h-1.5 rounded-full border border-white dark:border-gray-950"></i>
+                      )}
+                    </a>
                   </td>
                 ))}
                 <td class="py-1.5 pl-2 text-right font-mono text-xs text-gray-500 dark:text-gray-400 tabular-nums">
@@ -155,13 +183,26 @@ for (const p of papers) for (const c of cells(p)) counts[c.state] = (counts[c.st
       </table>
     </div>
 
-    <div class="flex flex-wrap gap-x-5 gap-y-2 text-xs text-gray-500 dark:text-gray-400 mb-12">
+    <div class="flex flex-wrap gap-x-5 gap-y-2 text-xs text-gray-500 dark:text-gray-400 mb-3">
       {Object.entries(counts).sort().map(([s, n]) => (
         <span class="flex items-center gap-2">
           <i class={`inline-block w-3 h-3 rounded-sm ${TONE[s] ?? TONE.absent}`}></i>
           {STATE_LABEL[s as keyof typeof STATE_LABEL] ?? s} {n}
         </span>
       ))}
+    </div>
+    {/* The colour is the mechanism; the mark is adjudication. Kept as its own line so the two
+        facts are not read as one — the whole point of the change. */}
+    <div class="flex flex-wrap gap-x-5 gap-y-2 text-xs text-gray-500 dark:text-gray-400 mb-12">
+      <span class="flex items-center gap-2">
+        <i class="relative inline-block w-3.5 h-3.5 rounded-sm bg-gray-200 dark:bg-gray-700"><i class="absolute inset-0 m-auto w-1.5 h-1.5 rounded-full bg-white dark:bg-gray-950 ring-1 ring-gray-900/40"></i></i>
+        {ADJUDICATION_LABEL.approved} — a person read and approved this version
+      </span>
+      <span class="flex items-center gap-2">
+        <i class="relative inline-block w-3.5 h-3.5 rounded-sm bg-gray-200 dark:bg-gray-700"><i class="absolute inset-0 m-auto w-1.5 h-1.5 rounded-full border border-white dark:border-gray-950"></i></i>
+        {ADJUDICATION_LABEL.partial} — a reading is under way
+      </span>
+      <span>no mark — {ADJUDICATION_LABEL.unread}</span>
     </div>
 
     <!-- ── approval, which is not a state ────────────────────────── -->


### PR DESCRIPTION
Closes #104.

A cell folds three different decisions into one badge. This shows three, per
`docs/design/2026-09-12-kinds-of-decision.md`:

- **Mechanism** — the ledger's state (current / stale / blocked / absent / n/a / run not observed). The cell's colour, unchanged.
- **Scheme** — the layer's declaration: accepted / proposed / open, and *provisional* on a cell whose needed corpus-scope declaration (relation-vocab or the like) is not accepted.
- **Adjudication** — whether a person has read this version: approved v<N> by <who>, partial (k of n considered), superseded, or unread.

## `pipeline.py approve --declaration <layer> --by NAME [--note ...]`

Records a scheme ruling. It appends to a corpus-level `runs/approvals.jsonl` an
entry naming the layer, the declaration's version, who, when and the note. The
declaration version is a hash of the layer's `layers.yaml` entry plus the files
its `reads` names (the prompt task, the vocabulary) — reusing `digest`, the same
machinery staleness uses, rather than a second hash.

`declaration_state()` reports, per layer, whether its declaration is `accepted`
(a ruling matches the current hash), `proposed` (the entry says so, or the
declaration moved past what was approved) or `open`, and which corpus-scope
decisions each layer is `provisional_on`. `state` is unchanged; the per-paper
`approvals.jsonl` shape is followed exactly.

## The site

`corpus_facts.py` feeds both new facts through `corpus-facts.json`
(`pipeline.declarations`, and per-version verdict counts read from
`claim-tree.v<N>.verdicts.jsonl`), matching how the badge is already fed — the
site does not read the ledger at build time.

- The **matrix** keeps mechanism as the cell's colour and adds a small mark for adjudication (a dot for approved, a ring for partial), so "which papers has a person read" is visible at corpus altitude. Gädeke and Kämmer's approved `gap-claim` cells now carry the mark.
- The **cell page** carries all three as chips, with Provisional and Approved/partial detail boxes.
- The **layer page** carries the scheme badge for the declaration, with who accepted it and when, beside a counter of papers adjudicated under it.

## Gates

- `PYTHON=~/anaconda/bin/python make check` — exit 0. `scripts/test_pipeline_versions.py` is now run by it, and carries new tests for declaration hashing and the open → accepted → superseded state transitions.
- `PYTHON=~/anaconda/bin/python make data` then `git status` — only `site/src/data/corpus-facts.json` changed (the two new keys); a second `make data` is a no-op.
- `cd site && CORPUS=elife npx astro build` — 660 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)