### PR TITLE
fix(layers): add missing title to gap-claim and edge-review layers

### DIFF
--- a/extract/tests/test_layer_contract.py
+++ b/extract/tests/test_layer_contract.py
@@ -122,6 +122,18 @@ def test_every_declared_command_names_a_real_subcommand():
             assert m.group(1) in choices, f"{lid}: command names missing subcommand {m.group(1)!r}"
 
 
+def test_every_layer_has_a_title():
+    """A layer without `title:` renders its cell page with a `<title>` of "undefined — pipeline".
+
+    The dynamic route site/src/pages/pipeline/[layer].astro interpolates `layer.title`
+    directly into the HTML title tag; a missing field produces the string "undefined" rather
+    than an error, so the omission only surfaces as a broken page title rather than a build
+    failure.
+    """
+    for lid, layer in _declaration().items():
+        assert layer.get("title"), f"{lid}: missing required `title:` field"
+
+
 def test_induction_layers_all_have_runners():
     """The five layers `pipeline.py run` used to refuse, and the two added with them.
 

--- a/pipeline/layers.yaml
+++ b/pipeline/layers.yaml
@@ -862,6 +862,7 @@ layers:
   - id: gap-claim
     group: measures
     kind: candidate
+    title: Gap claims
     question: What claim would close each gap?
     needs: [adjudication, claim-tree, claim-format]
     reads: [extract/prompts/gap-claim.md, scripts/gap_claims.py]
@@ -895,6 +896,7 @@ layers:
 
   - id: edge-review
     kind: step
+    title: Edge review
     question: What does a claim added after induction depend on and support?
     needs: [claim-tree, relation-vocab]
     reads: [extract/prompts/edge-inference.md, extract/prompts/contract/vocabulary.md,

--- a/site/src/data/corpus-facts.json
+++ b/site/src/data/corpus-facts.json
@@ -586,7 +586,7 @@
           "relation-vocab"
         ],
         "scheme": "open",
-        "version": "8be601c18783"
+        "version": "bf24f6168aee"
       },
       "epistemic-vocab": {
         "provisional_on": [
@@ -621,7 +621,7 @@
           "relation-vocab"
         ],
         "scheme": "open",
-        "version": "fa9fde472418"
+        "version": "2f2e2dda68cb"
       },
       "marks": {
         "provisional_on": [
@@ -1452,6 +1452,7 @@
           "extract/prompts/gap-claim.md",
           "scripts/gap_claims.py"
         ],
+        "title": "Gap claims",
         "views": [
           "table"
         ]
@@ -1475,6 +1476,7 @@
           "extract/prompts/contract/vocabulary.md",
           "scripts/edge_review.py"
         ],
+        "title": "Edge review",
         "views": [
           "table"
         ]


### PR DESCRIPTION
Both layers lacked a `title:` field. The dynamic route `site/src/pages/pipeline/[layer].astro` interpolates `layer.title` directly into the HTML title tag:

\`\`\`astro
<Layout title={`${layer.title} — pipeline`} ...>
\`\`\`

A missing field silently produces `"undefined — pipeline"` rather than a build error.

## Changes

- **`pipeline/layers.yaml`**: adds `title: Gap claims` to `gap-claim` and `title: Edge review` to `edge-review`. Both follow the short noun-phrase style of their neighbours (`Edge inference`, `External review`, `Marked paper`). No other layer was missing a title.

- **`extract/tests/test_layer_contract.py`**: adds `test_every_layer_has_a_title`, which iterates all declared layers and fails any that lack the field. This prevents the regression from recurring.

- **`site/src/data/corpus-facts.json`**: regenerated by `make data`; picks up the new titles and updated `layers.yaml` version hashes.

## Gates

| Gate | Result |
|---|---|
| `PYTHON=~/anaconda/bin/python make check` | exit 0 — 43/43 layer contract tests pass including `test_every_layer_has_a_title` |
| `PYTHON=~/anaconda/bin/python make data && git status` | only intended generated changes (corpus-facts.json) |
| `cd site && CORPUS=elife npx astro build` | 660 pages built, exit 0 |
| `gap-claim` page title | `Gap claims — pipeline — eLife Claim Trees` |
| `edge-review` page title | `Edge review — pipeline — eLife Claim Trees` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)