### PR TITLE
feat(skills): claim-structures agent skill

### DIFF
--- a/.claude/skills/claim-structures/SKILL.md
+++ b/.claude/skills/claim-structures/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: claim-structures
+description: "Work with claim structures — typed propositions joined by typed logical relations (hypothesis entails prediction, empirical result tests it, control rules out an alternative, scope bounds it). Use when analyzing a paper into claims, speccing or outlining a paper around its argument, designing an experiment around what it has to rule out, auditing an argument for gaps, or authoring and editing claim files in a claim-tree corpus."
+---
+
+A claim structure is a scientific argument written as data: one declarative proposition per
+node, one typed logical relation per edge. It is the same object whether you are reading a
+finished paper, planning one, or designing the experiment that will fill it — what changes is
+which end you start from.
+
+## What a claim is
+
+A claim is an **entity**, not a result and not a figure. `dat-reuptake-dominates` is a
+proposition about the world that several papers might assert, that a reproduction might test,
+and that other claims might depend on. A *paper* asserts a claim, in a particular panel, with a
+particular analysis, on particular data — that pairing is an **assertion**, and it is a property
+of the paper, not of the claim. The same proposition can be asserted by one paper and rejected
+by another; both assertions hang off the one claim, and the disagreement becomes visible.
+
+Relations between claims are **not citations**. `A requires B` says A would be invalid if B were
+false. That is why the structure is worth building: invalidity propagates along the edges, so a
+claim that fails is not an isolated correction but a traceable one.
+
+## The minimal claim
+
+```yaml
+---
+uuid: 26819b09-5b20-4c90-b9f3-8bdd29a2a57c   # uuid4, generated once, never changes
+slug: distal-inhib-drops-firing-02hz          # 3-6 words, lowercase, verb phrase
+claim: >
+  Doubling the strength of distal dendritic inhibition reduces somatic firing rate from
+  approximately 5.5 Hz to approximately 0.2 Hz, primarily by suppressing dendritic Ca²⁺ and
+  NMDA spikes rather than by directly raising AP threshold.
+claim-type: empirical        # what kind of proposition it is
+role: empirical              # what work it does in the argument
+epistemic: strong            # strong | moderate | weak | contested
+concepts: [distal dendritic inhibition, somatic firing rate, dendritic spike suppression]
+
+tests: [prediction-distal-dendritic-spike-mechanism]
+requires: [l5-model-single-cell-scope]
+dissociates-with: [perisomatic-inhib-drops-firing-07hz]
+
+assertions:
+  - paper-slug: headley-2026-inhibitory-rhythms
+    doi: 10.7554/eLife.95562
+    panel: fig4, fig5
+    analysis: scripts/Fig4.ipynb
+    dataset-doi: 10.5061/dryad.v6wwpzhb8
+    method: compartmental modelling — inhibition magnitude sweep
+    confidence: strong
+    stance: asserts          # asserts | entertains | rejects | attributes
+---
+
+Prose body: caveats, boundary conditions, why this edge and not that one.
+```
+
+Full field reference: [references/schema.md](references/schema.md).
+Relation vocabulary, directions and the pairs people confuse: [references/relations.md](references/relations.md).
+
+## The two axes
+
+`claim-type` is the **epistemic character** of the proposition — empirical, interpretive,
+existence, synthesis, assessment, hypothesis, prediction. `role` is the **rhetorical function**
+it serves in this argument — hypothesis, prediction, empirical, control, scope, methodological,
+synthesis, interpretation, literature-context.
+
+They are orthogonal, and the distinction is load-bearing. A `claim-type: empirical` proposition
+is `role: empirical` when it is a finding, `role: control` when its job is to kill a rival, and
+`role: scope` when its job is to bound what the others mean. The same measurement does
+different work in different arguments.
+
+## The spine
+
+```
+question
+  ├── hypothesis  (the answer the work commits to)
+  │     └─ entails → prediction ←─ tests ── empirical result
+  │                                              ├─ requires → scope, methodological
+  │                                              └─ supports → synthesis → interpretation
+  └── alternative (a rival answer, stance: entertains)
+        ←─ rules-out ── control
+```
+
+Every workflow below walks this spine. Analysis walks it upward from the panels; a paper spec
+walks it downward from the question; an experimental design walks it sideways, from the rivals
+that have to be eliminated to the measurements that eliminate them.
+
+## Pick the workflow
+
+| You are… | Read |
+|:---------|:-----|
+| turning a published or drafted paper into claims | [workflows/analyze-paper.md](workflows/analyze-paper.md) |
+| speccing or restructuring a paper you are writing | [workflows/spec-paper.md](workflows/spec-paper.md) |
+| designing an experiment or study before data exists | [workflows/design-experiment.md](workflows/design-experiment.md) |
+| checking a structure someone else built | [references/checks.md](references/checks.md) |
+
+## Invariants
+
+These hold in all three workflows. Most defects found in real claim trees are violations of one
+of them.
+
+1. **One sentence, one claim.** A proposition needing two sentences is two claims. Two results
+   joined by "and" are two claims — or one whole with two `part-of` components, if neither
+   states the proposition on its own.
+2. **Quantitative where the result is.** Put the numbers in the claim sentence, taken verbatim
+   from the source. Never compute, round, or infer a value that the source does not state —
+   a plausible fabricated number is the failure mode a reader cannot catch.
+3. **The alternative needs a node.** A control exists to eliminate a rival, so the rival must
+   exist as a claim for `rules-out` to reach. A control whose edges name only the claim it
+   defends has not recorded the point of the control.
+4. **Never oppose what you assert.** `rules-out`, `contradicts` and `opposes` may not point at a
+   claim the same paper asserts. When the real target has no node, the edge drifts to the
+   nearest claim that does — structurally valid, factually false. (`refutes` at one's own
+   prediction is different, and correct: that is the hypothetico-deductive loop closing.)
+5. **Direction is part of the relation.** `entails` runs down from hypothesis to prediction;
+   `tests` runs up from result to prediction. They are neither interchangeable nor reciprocal.
+6. **Scope before results.** Write what the work does *not* establish — the model's boundary,
+   the population, the stimulation regime — as scope claims, and point them at what they bound.
+   Written afterwards, they become a discussion paragraph nobody traverses.
+7. **The graph is the argument.** Read the edges alone, with the claim sentences, and see
+   whether the argument reconstructs. If it does not, the edges are wrong — not the reader.
+8. **Do not fabricate identifiers.** Generate UUIDs (`python3 -c "import uuid; print(uuid.uuid4())"`).
+   Take panel ids from the source's own figure elements. Leave `doi: ~` unless the DOI is real.
+
+## Stance, and why it is on the assertion
+
+A paper does not only assert. It raises candidates it does not commit to (`entertains`), argues
+that some are false (`rejects`), and reports what others claimed (`attributes`, which requires a
+source). Stance says what the paper concluded; the edges say why. Keep both — a paper can
+dismiss a rival with no evidence at all, and conversely the `rules-out` edge names which control
+did the work, which stance cannot.
+
+## In this repository
+
+The corpus, the schema and the tooling live here:
+
+```bash
+python3 scripts/pipeline.py run <paper> claim-tree --dry-run   # what producing a tree would do
+python3 scripts/check_relations.py                             # stance and edge legality
+make check                                                     # the gate CI enforces
+```
+
+`docs/claim-format.md` is the normative format, `docs/vocabulary.md` the role and relation
+reference, `docs/method.md` the full method including verification. `claims/<paper>/` holds
+worked examples — `headley-2026-inhibitory-rhythms` is the cleanest complete spine.
+
+Note that no human has verified any claim in this corpus (`docs/method.md` § 3). Treat existing
+files as a draft annotation layer to imitate structurally, not as adjudicated content.

--- a/.claude/skills/claim-structures/references/checks.md
+++ b/.claude/skills/claim-structures/references/checks.md
@@ -1,0 +1,84 @@
+# Checks
+
+Run these before handing over any claim structure, whether you built it or are auditing someone
+else's. They are ordered by how often they catch something real.
+
+## Structural errors
+
+These are errors, not style. Each one makes the graph assert something false.
+
+1. **An opposing edge aimed at an asserted claim.** `rules-out`, `contradicts` and `opposes` may
+   not target a claim the same paper asserts. The cause is almost always a missing alternative
+   node, and the fix is to author it — never to redirect the edge. (`refutes` at the paper's own
+   prediction is legal and correct.)
+2. **A dangling target.** An edge naming a slug no claim has. Either the target was never
+   written or the slug was renamed and the edge not followed. `scopes: ["*"]` is the one legal
+   non-slug target.
+3. **Both supporting and opposing the same target.** A pair carrying, say, `supports` and
+   `rules-out` cannot both be meant. (`dissociates-with` alongside `supports` is the known
+   ambiguous case — flag it for review rather than failing it.)
+4. **`stance: attributes` with no source.** An attributed claim must say who asserts it.
+5. **An unknown stance, role, claim-type, relation or status.** The vocabularies are closed.
+   Inventing a value hides the claim from every query written against the schema.
+6. **A number in a claim sentence that is not in the source.** The one defect a reader cannot
+   detect. Re-check every value against the text it came from.
+7. **A fabricated identifier.** A guessed DOI, a hand-written UUID, a panel id that is not the
+   publisher's. Generate UUIDs properly; leave `doi: ~`.
+
+In a corpus with the tooling:
+
+```bash
+python3 scripts/check_relations.py          # stance and edge legality, all papers
+python3 scripts/check_relations.py --warnings <paper>
+make check
+```
+
+## Structural smells
+
+Not errors — read each one and decide.
+
+| Smell | Usually means |
+|:------|:--------------|
+| a control with no `rules-out` | the alternative it eliminates has no node |
+| an alternative (`entertains`) with no incoming `rules-out` | an open rival — legitimate, but say so deliberately |
+| a prediction with no incoming `tests` | an untested commitment |
+| an empirical claim with no outgoing edges | an orphan result, or a missing hypothesis |
+| a hypothesis with one `entails` | a single point of contact with the world |
+| no `scope` claims anywhere | boundaries unexamined, not absent |
+| no `requires` edges | the dependencies are real and unwritten |
+| every edge is `supports` | no deductive spine; nothing entails and nothing tests |
+| a synthesis with one `supports` | an integration of one thing |
+| two claims with near-identical sentences | one claim, or a whole plus a `part-of` component |
+| a claim needing two sentences | two claims |
+| an `interprets` edge doing a derivation's work | the reconstruction overstates what was shown |
+
+## Direction check
+
+Walk every edge and read it aloud as a sentence. The direction is wrong more often than the
+type:
+
+- `A entails B` — "if A holds, B follows." A is the hypothesis, B the prediction.
+- `A tests B` — "measuring A settles B." A is the result, B the prediction.
+- `A rules-out B` — "A's evidence eliminates B." B is a rival the paper does not assert.
+- `A requires B` — "A would be invalid if B were false." A is the dependent claim.
+- `A scopes B` — "A bounds what B can mean." A is the boundary condition.
+- `A supports B` — "A is evidence for B." A survives B being false.
+- `A part-of B` — "A is one component of what B states whole."
+
+## The reconstruction test
+
+The one check that catches what the others miss: read the claim sentences and the edges, with
+the paper closed, and write the argument out in a paragraph. Then compare it to the abstract.
+
+- If your paragraph reconstructs the argument, the graph is sound.
+- If it reconstructs something *more* than the abstract — the eliminated alternatives, the
+  controls, the scope — that is expected and is the point.
+- If it reconstructs something *less*, or something different, the edges are wrong. Find the
+  step your paragraph could not make and look at the claims on either side of it.
+
+## Reporting
+
+State in the handoff what you could not settle: reconstructed hypotheses and predictions,
+single-source readings, numbers not found verbatim, alternatives you paraphrased, coverage gaps,
+and every place you guessed. A structure whose uncertainties are unreported is not a finished
+structure — it is an unreviewed one, and it reads as finished, which is worse.

--- a/.claude/skills/claim-structures/references/relations.md
+++ b/.claude/skills/claim-structures/references/relations.md
@@ -1,0 +1,139 @@
+# Relations
+
+A relation is a proposition about logical structure between two claims — never a citation.
+Each is a top-level YAML key whose value is a list of target slugs:
+
+```yaml
+tests: [prediction-distal-dendritic-spike-mechanism]
+requires: [l5-model-single-cell-scope, naturalistic-drive-parameterization]
+rules-out: [alt-distal-inhibition-raises-somatic-threshold]
+```
+
+An older list form, `belongings: [{relation: requires, target: …}]`, is equivalent and appears in
+existing corpora. Both are the schema; a tool that reads only one undercounts.
+
+## The vocabulary
+
+| Relation | Reasoning form | What it asserts | Direction |
+|:---------|:---------------|:----------------|:----------|
+| `requires` | dependency | A would be invalid if B were false | from the dependent claim to its prerequisite |
+| `supports` | abduction | A is evidence for B | from the evidence to what it is evidence for |
+| `entails` | deduction | A (a hypothesis) deductively implies B | from the hypothesis down to the prediction |
+| `derived-from` | deduction | reciprocal of `entails` | from the prediction back up to its hypothesis |
+| `tests` | deduction → empirical | empirical A tests prediction B, closing the loop | from the result up to the prediction |
+| `refutes` | negative abduction | A's evidence is incompatible with B | from the evidence to the prediction/hypothesis/alternative |
+| `rules-out` | elimination | A's evidence eliminates alternative B | from the control to the alternative — never to an asserted claim |
+| `dissociates-with` | dissociation | A and B jointly establish a dissociation | symmetric; direction carries no meaning |
+| `validates` | disconfirmation control | A's specific result strengthens B's warrant | from the control to the claim it warrants |
+| `predicts` | predictive validation | A predicts B, typically model to experiment | from the model to the observation |
+| `confirms` | predictive validation | reciprocal of `predicts` | from the result to what it confirms |
+| `interprets` | reframing | A reframes empirical B through a theoretical lens | from the interpretation to the result |
+| `enables-method` | methodological warrant | A is the capability that warrants B's interpretability | from the capability to the result |
+| `scopes` | scope qualification | A bounds B, or every empirical claim if `["*"]` | from the scope claim to what it bounds |
+| `extends` | extension | A extends B beyond its original conditions | from the later or broader result |
+| `qualifies` | qualification | A narrows B without contradicting it | from the qualifying result |
+| `contradicts` | opposition | A and B cannot both hold | either direction |
+| `opposes` | opposition | A stands against B | from the claim that stands against |
+| `replicates` | replication | A is an independent finding of the same result | from the independent finding |
+| `part-of` | composition | A is one comparison, condition, measure or study of the whole B states | from the component to the whole |
+
+## The six moves
+
+**Deduction.** `entails` and `derived-from` carry the hypothesis-to-prediction arc. One
+hypothesis normally entails several predictions; each is derived-from it.
+
+**Induction and support.** `requires` and `supports` carry dependency and evidence. A standalone
+empirical claim outside any hypothesis loop still supports the higher-order claims it grounds.
+
+**Abduction.** `supports` and `refutes` running from results back to hypotheses close the
+abductive loop: a result that supports one hypothesis while refuting the prediction of its rival
+is abduction by elimination.
+
+**Elimination.** `rules-out` is the move a control makes. It needs a target the paper does not
+assert, which is why alternatives are authored as claims.
+
+**Dissociation.** `dissociates-with` joins two results that are both true and *differ*; the
+contrast is the finding. It is the one relation where direction carries no meaning.
+
+**Scope and warrant.** `scopes` and `enables-method` say where a result stops and what makes it
+interpretable. They run *from* the bounding or enabling claim *to* the results affected —
+opposite to `requires`, which runs from the result to what it depends on.
+
+## Pairs that get confused
+
+**`requires` vs `supports`.** `requires` is dependency: if the target were false the source
+would be invalid. `supports` is evidence: the source makes the target more credible and survives
+its falsity. One empirical claim commonly carries both — it *requires* the scope claim bounding
+the model it was computed in, and *supports* the hypothesis it was run to test.
+
+**`entails` vs `tests`.** Both connect a hypothesis's arc, in opposite directions and from
+different roles. `entails` runs down and is deductive: the prediction follows if the hypothesis
+holds. `tests` runs up from a measured result to the prediction it settles. A result never
+entails; a hypothesis never tests.
+
+**`rules-out` vs `refutes`.** `rules-out` eliminates an *alternative* — a claim raised in order
+to reject, with a node of its own and stance `entertains` or `rejects`. `refutes` aims at one of
+the paper's *own* predictions or hypotheses that the evidence came out against; a paper refuting
+its own prediction is the hypothetico-deductive loop closing correctly, not an error.
+
+**`dissociates-with` vs `contradicts`.** A dissociation joins two results that are both true and
+differ. A contradiction says two claims cannot both hold. Two conditions producing different
+effects is a dissociation, and calling it a contradiction destroys the finding.
+
+**`scopes` vs `requires`.** The same pair of claims can carry both, in opposite directions: the
+result requires the scope; the scope scopes the result. Pick the direction by asking which claim
+is doing the bounding.
+
+**`validates` vs `supports`.** `validates` is a control's edge — a check whose *specific*
+outcome (a null where a confound would have produced an effect, a sign flip, a manipulation
+check) strengthens a warrant. `supports` is ordinary evidence. A control validates; a main
+result supports.
+
+**`part-of` vs `supports`.** `part-of` is composition: the source is one comparison, condition,
+measure or study *of* the proposition the target states whole, and removing it weakens the
+target without falsifying it. `supports` is an independent finding that would survive removal. A
+filter on `supports` cannot tell a component from an independent finding, which is why
+composition needs its own relation.
+
+## Worked spine
+
+From `headley-2026-inhibitory-rhythms`, the shape to imitate:
+
+```
+hypothesis-distinct-compartmental-roles            (role: hypothesis)
+  entails → prediction-distal-dendritic-spike-mechanism
+  entails → prediction-perisomatic-threshold-mechanism
+  entails → prediction-perisomatic-input-output-shaping
+  entails → prediction-orthogonal-input-gating
+
+distal-inhib-drops-firing-02hz                     (role: empirical, fig4/fig5)
+  tests            → prediction-distal-dendritic-spike-mechanism
+  rules-out        → alt-distal-inhibition-raises-somatic-threshold
+  dissociates-with → perisomatic-inhib-drops-firing-07hz
+  requires         → l5-model-single-cell-scope
+  requires         → naturalistic-drive-parameterization
+  supports         → hypothesis-distinct-compartmental-roles
+
+l5-model-single-cell-scope                         (role: scope)
+  scopes → ["*"]
+
+pv-gamma-sst-beta-correspondence                   (role: interpretation)
+  interprets → the four empirical claims it reframes
+  requires   → interprets-pv-gamma-sst-beta-associations   (role: literature-context)
+```
+
+Read that alone and the argument reconstructs: a dissociation hypothesis, four predictions, a
+pair of contrasting measurements that test two of them and jointly establish the dissociation, a
+model boundary on everything, and an interpretation that reaches outside to prior literature
+through an explicit node rather than an unnamed referent.
+
+## Open question
+
+Whether `supports` and a hypothetical `consistent-with` assert different things, and whether
+opposition is one relation or three (`contradicts` / `opposes` / `rules-out`), is unsettled.
+`dissociates-with` in particular is declared as an opposition but used alongside supporting
+relations on the same pair — coherent only if it means "these come apart" rather than "the
+target is wrong". Everything downstream of that question is provisional in the exact sense that
+it would change if the answer did. Do not resolve it silently in a new tree: use `rules-out` for
+elimination, `dissociates-with` for contrast, and leave `contradicts` and `opposes` for cases
+where two claims genuinely cannot both hold.

--- a/.claude/skills/claim-structures/references/schema.md
+++ b/.claude/skills/claim-structures/references/schema.md
@@ -1,0 +1,208 @@
+# Claim schema
+
+One file per claim: YAML frontmatter over an optional markdown body. The body carries what does
+not compress into fields — caveats, boundary conditions, why one edge and not another.
+
+Canonical path in a corpus: `claims/<paper-slug>/<claim-slug>.md`, with an `index.md` per paper.
+
+## Required fields
+
+| Field | Value |
+|:------|:------|
+| `uuid` | UUID4, generated once at creation, immutable. `python3 -c "import uuid; print(uuid.uuid4())"` |
+| `slug` | filename slug: lowercase, hyphenated, 3–6 words, a verb phrase naming the proposition |
+| `doi` | `~` — claims are not yet citable units. Exception: a `literature-context` claim puts the *cited paper's* DOI here |
+| `claim` | one declarative sentence, active voice, quantitative where the result is quantitative |
+| `claim-type` | `empirical` / `interpretive` / `existence` / `synthesis` / `assessment` / `hypothesis` / `prediction` |
+| `role` | one of the nine below |
+| `concepts` | domain terms the claim touches; the handle for cross-paper retrieval |
+| `priority` | date the claim was first registered (ISO) |
+| `epistemic` | `strong` / `moderate` / `weak` / `contested` — support across *all* assertions, not this paper's confidence |
+| `assertions` | list of blocks tying the claim to paper / panel / analysis / data |
+| `reproductions` | list of verification attempts; `[]` when none |
+
+`epistemic` is the analyst's standing assessment and gets revised: a claim asserted `strong` by
+one paper and failing reproduction in another moves to `contested`. It is bounded by the weakest
+claim it `requires` — that is the point of registering assumptions as claims.
+
+## Claim types
+
+| Type | Definition |
+|:-----|:-----------|
+| `empirical` | a directly observed or computed result |
+| `interpretive` | an inference drawn from one or more empirical claims |
+| `existence` | an assertion that a phenomenon or entity exists |
+| `synthesis` | a proposition integrating results across analyses, papers or datasets |
+| `assessment` | a methodological or quality claim — a parameter, an assumption, a capability |
+| `hypothesis` | a proposition bet on, not yet evidenced by this work's results |
+| `prediction` | a deduced expectation, to be tested by an empirical claim |
+
+## Roles
+
+Role governs which edges a claim may carry and how a reader reconstructs the argument from the
+graph alone. It is the most consequential field after `claim`.
+
+| Role | What it marks | Signals in prose | Typical type |
+|:-----|:--------------|:-----------------|:-------------|
+| `hypothesis` | the organising bet the rest defends | "we hypothesize", "we asked whether", "we sought to test" | `hypothesis` |
+| `prediction` | the deductive consequence under stated conditions | "if X then we should observe Y", "the model predicts" | `prediction` |
+| `empirical` | a measured or computed result, panel-grounded | "we found", "we measured", "Figure N shows" | `empirical` |
+| `control` | a result whose work is to eliminate a rival | "rules out", "excludes", "not due to", "no effect of [confound]" | `empirical` |
+| `scope` | a boundary condition on the empirical claims | "all results come from", "the model assumes", "restricted to" | `assessment` |
+| `methodological` | a procedural capability that warrants an interpretation | "sorting uses Kilosort 2.5", "modeled as sinusoidal modulation" | `assessment` |
+| `synthesis` | several results integrated, staying inside this work's evidence | "taken together", "these results show", "this dissociation establishes" | `synthesis` |
+| `interpretation` | a reframing through a theoretical lens, reaching outside | "may provide a functional interpretation", "suggests a role for" | `interpretive` |
+| `literature-context` | a cited prior result as a first-class node | "as shown by Author (Year)", "previous work established" | `interpretive` |
+
+Notes that matter in practice:
+
+- A **hypothesis** holds no empirical content and does not `requires` empirical claims —
+  its predictions do that. Its panel is normally null; a hypothesis is paper-level.
+- An **empirical** claim is panel-grounded by definition. If you cannot name the panel, table or
+  analysis block, it is probably a synthesis or an interpretation.
+- **control** vs **empirical** is functional, not contentful: the same proposition is `control`
+  here and `empirical` in a paper that reports it as a finding.
+- **scope** is often global: `scopes: ["*"]` qualifies every empirical claim in the paper.
+- **synthesis** stays inside the paper's own evidence; **interpretation** maps onto outside
+  theory. Reading an interpretation as a derivation is the commonest way a reconstruction
+  overstates what the work showed.
+- **literature-context** exists so eliminative and interpretive moves have an explicit referent.
+  Without a node for "multiplicative gain control", `rules-out: multiplicative-gain-control` is
+  an eliminative move against an unnamed alternative.
+
+## Questions
+
+A question is not a claim — a claim is a declarative sentence — so it is not a node. It lives in
+the paper's `index.md` frontmatter:
+
+```yaml
+questions:
+  - id: q1
+    text: "Does the anterior insula encode responsibility-contingent interpersonal guilt?"
+```
+
+A `hypothesis` names the question it answers via top-level `addresses: q1`; so does a rejected
+alternative, which is one of the *other* answers to the same question. Every other role omits
+the field. A hypothesis and the alternatives it competes with normally share one `addresses` —
+that shared id is what makes them rivals rather than unrelated propositions.
+
+## Assertions
+
+One block per paper that asserts the claim. The panel is a property of the assertion, not of the
+claim: `fig2a` says how *this* paper chose to show the proposition.
+
+```yaml
+assertions:
+  - paper-slug: headley-2026-inhibitory-rhythms
+    doi: 10.7554/eLife.95562
+    panel: fig4, fig5              # publisher's own figure id where available
+    figureUri: https://…           # optional, for rendering
+    scope: tissue-scale            # varicosity-scale | tissue-scale | in-vivo | ex-vivo | in-vitro
+    analysis: scripts/Fig4.ipynb
+    dataset: https://datadryad.org/dataset/doi:10.5061/dryad.v6wwpzhb8
+    dataset-doi: 10.5061/dryad.v6wwpzhb8
+    method: compartmental modelling — inhibition magnitude sweep
+    confidence: strong             # this paper's own confidence
+    stance: asserts                # asserts | entertains | rejects | attributes
+    source: "Servan-Schreiber et al. 1990"   # required when stance is `attributes`
+```
+
+### Stance
+
+| Value | Meaning |
+|:------|:--------|
+| `asserts` | the paper claims the proposition is true — **default** when absent |
+| `entertains` | it is raised as a candidate and not asserted |
+| `rejects` | the paper argues it is false |
+| `attributes` | someone else asserts it; this paper reports that. Requires `source` |
+
+There is no "rejected" value. A claim asserted with `entertains` and an incoming `rules-out`
+**is** a rejected alternative; with `entertains` and no such edge it is an *open* alternative —
+a rival raised and not settled, which is a finding about the paper worth keeping.
+
+### Alternatives are claims
+
+When a paper rules out a confound, a rival mechanism, or a competing account, the thing ruled
+out gets a file like any other. Its role is whatever it functionally is (usually `hypothesis`);
+what marks it as a rival is the stance on its assertion.
+
+```yaml
+uuid: …
+slug: alt-social-context-shifts-risk-attitude
+claim: >
+  The happiness difference between Social and Partner conditions reflects a social-context-driven
+  shift in risk attitude rather than responsibility-contingent guilt.
+role: hypothesis
+epistemic: weak
+addresses: q2
+assertions:
+  - paper-slug: gadeke-2026-guilt-insula
+    stance: rejects
+    method: agent extraction from the paper's control analyses
+```
+
+and the control that kills it carries `rules-out: [alt-social-context-shifts-risk-attitude]`.
+
+## Reproductions
+
+```yaml
+reproductions:
+  - agent: mainen-z                # the identity that ran it — not a person who read it
+    date: 2026-03-30
+    status: verified
+    script: verification/<paper>/verify.py
+    original_script: https://github.com/…/Fig4.ipynb
+    script_execution: unmodified   # unmodified | patched | from-notes
+    figure: verification/<paper>/fig4a-firing-rates.png
+    time_fast: "~2 min"
+    time_full: "~6 hrs (NEURON + 1.88 GB Dryad)"
+    notes: >
+      Pre-computed firing rates (30 trials/condition): control 5.5±0.86 Hz, dendritic
+      0.2±0.15 Hz, somatic 0.7±0.31 Hz — exact matches for the claimed values.
+```
+
+| Status | Meaning |
+|:-------|:--------|
+| `verified` | ran it; output matches within tolerance |
+| `verified:partial` | ran a defined subset; matched portion named in `notes` |
+| `failed:mismatch` | ran it; output does not match — discrepancy diagnosed in `notes` |
+| `unverified` | not attempted |
+| `unverified:no-data` / `unverified:no-code` | deposit not accessible |
+| `unverified:code-error` | errors before producing output; record the exact error |
+| `unverified:compute-infeasible` | would need compute beyond available resources |
+
+`notes` carries the evidentiary weight. "Numbers differ" is not a record. "Clearance rate
+constant 0.31 s⁻¹ in reproduction vs 0.18 s⁻¹ in paper; suspect different initial conditions"
+is. A status written from what the analysis was *expected* to show is the one failure mode a
+later reader cannot detect — record what the code actually opened and actually returned.
+
+## Auxiliary fields
+
+- `displayClaim` — one to two sentences, the form rendered in body text and cards. Softens the
+  formal sentence without changing the proposition.
+- `shortClaim` — a single clause, ≤90 characters, for graph nodes and tooltips. Required for
+  synthesis, interpretation and literature-context nodes, which must read at a glance.
+- `number` / `numberParts` — **computed at build** from role and graph position (`H1.P2.E1`).
+  Never author these by hand.
+
+## Conditionality is graph structure
+
+When a result depends on an assumed parameter, a methodological choice, or an untested
+boundary, do not annotate it — register it as an `assessment` claim with its value, its source
+and whether it was sensitivity-tested, and point a `requires` edge at it.
+
+```yaml
+slug: d2r-initialization-unjustified
+claim: >
+  D2 receptor occupancy is initialized at 0.4 without derivation from steady state; at
+  EC50 = 7 nM and tonic [DA] ~10 nM, equilibrium occupancy would be ≈0.59. No sensitivity
+  analysis over this parameter is reported.
+claim-type: assessment
+role: scope
+epistemic: weak
+```
+
+Three kinds always deserve this treatment: model-parameter assumptions taken from literature
+rather than measured; scope separations where a simulation runs at a different scale from the
+paper's primary model; and untested methodological choices (initialization, thresholds,
+boundary conditions). The weakness then propagates by traversal instead of by footnote.

--- a/.claude/skills/claim-structures/workflows/analyze-paper.md
+++ b/.claude/skills/claim-structures/workflows/analyze-paper.md
@@ -1,0 +1,140 @@
+# Analyze a paper into claims
+
+Reverse construction: a finished argument in prose goes in, a claim graph comes out. You are
+recovering a structure the authors had and did not write down.
+
+Expect 15–40 claims for a full-length primary research paper, plus components. A tree with six
+claims has collapsed the argument; one with a hundred has decomposed results into statistics.
+
+## 1. Get structured source text
+
+The format the text arrives in bounds everything downstream. Prefer the publisher's XML (JATS
+for eLife and most journals) over the PDF:
+
+| | JATS XML | PDF |
+|:--|:--|:--|
+| Section boundaries | tagged | inferred from heading text |
+| Figure captions | one element each, with its own id | recovered by position |
+| Figure identity | the publisher's own `fig2`, `fig3s1` | guessed from "Figure 2" |
+| Reading order | explicit | a column-order guess |
+
+eLife: `https://cdn.elifesciences.org/articles/<id>/elife-<id>-v1.xml`. Panel grounding is only
+as good as figure structure at intake — from JATS a `panel` field is the publisher's element id,
+from a PDF it is an inference about a label in running text.
+
+Slice the source into abstract, results, figure captions, methods, and keep the verbatim text
+you read. **Check the slice sizes before reading further.** A short results slice means section
+detection failed and everything downstream read the wrong text — a fault in intake that presents
+as a fault in reading.
+
+## 2. Read the abstract for the top and the questions
+
+Identify the two to four top-level claims — the paper's main bets — and write candidate slugs.
+These become the synthesis and interpretation nodes; they usually have no panel of their own.
+
+Write the paper's `questions` at the same time, from the introduction's closing paragraph and
+the abstract's setup. A question the paper answers but never states is still a question; record
+it and note that it is reconstructed.
+
+## 3. Walk the results, panel by panel
+
+For each panel, table or analysis block, ask: **what single proposition does this establish?**
+That is one empirical claim. Write it as one declarative sentence carrying the paper's own
+numbers, verbatim. If a panel establishes two propositions, it is two claims; if a proposition
+needs three panels, it is one claim with three panels in `assertions[].panel`.
+
+Where a claim states a whole that several comparisons each partly establish, write the whole and
+attach the components with `part-of` rather than inflating the count with near-duplicates.
+
+Capture provenance now, while the structured source is in front of you: panel id, figure URI,
+the analysis script or notebook, the dataset and its DOI. Guessing figure filenames from panel
+labels at a later build step loses information you have at this moment.
+
+## 4. Recover the spine
+
+Results give you the empirical layer. The spine is elsewhere:
+
+- **Hypotheses** — the introduction's closing paragraph and the abstract's "we sought to
+  test". Often unstated as such; a paper with results and no recoverable hypothesis is worth
+  noting rather than inventing one.
+- **Predictions** — sometimes explicit ("this predicts that"), more often implicit in how a
+  result is framed as confirming or disconfirming. Where implicit, write the prediction that
+  makes the test intelligible and say in the body that it is reconstructed.
+- **Controls** — "to rule out", "no effect of", "we verified that". For each, name the
+  alternative it eliminates and **give that alternative its own claim** with stance
+  `entertains` or `rejects`. This is the step most often skipped, and skipping it leaves the
+  control's edge pointing at whatever asserted claim is nearest.
+- **Scope** — "all results come from", "the model assumes", "restricted to". Also the limits
+  paragraph of the discussion, which is where scope claims hide in finished papers.
+- **Methodological** — the analytical capabilities the interpretations lean on: the sorting
+  pipeline, the pooling strategy, the null model. Register the ones a result *depends* on, not
+  every method mentioned.
+- **Literature-context** — prior results the argument inherits as premises, especially any
+  framework the paper positions itself against. If the paper rules out "gain control", gain
+  control needs a node or the eliminative move has no referent.
+
+## 5. Assign role and claim-type
+
+Two axes, assigned separately (see [references/schema.md](../references/schema.md)). Role is
+the more consequential: it governs numbering, grouping and how the argument reads back. A
+measurement whose job is to kill a confound is `role: control` even though its type is
+`empirical`.
+
+## 6. Draw the edges
+
+Work from the spine outward, checking direction on each
+([references/relations.md](../references/relations.md)):
+
+1. `entails` from each hypothesis down to its predictions.
+2. `tests` from each empirical result up to the prediction it settles.
+3. `rules-out` from each control to its alternative.
+4. `dissociates-with` between the pairs whose *contrast* is the finding.
+5. `requires` from results to the scope and methodological claims they depend on;
+   `scopes` and `enables-method` back the other way where the bounding claim is the subject.
+6. `supports` from results to the syntheses they ground; `interprets` from interpretations to
+   the results they reframe.
+
+If an edge is hard to type, the usual cause is that one endpoint is the wrong claim — most often
+a missing alternative or a missing scope claim.
+
+## 7. Coverage — what did you miss?
+
+Sweep the results text for every span carrying a statistic or a stated result, and check each
+against the tree. Three outcomes: **covered** by a claim, a real **gap**, or **asserting
+nothing** (a method restatement, a forward reference). Record the verdicts rather than
+recomputing them — a mechanical match on "does a claim restate this statistic" is wrong in both
+directions, and the residue is a judgement worth storing once.
+
+Gaps cluster in the discussion and in negative results the abstract does not carry. Those are
+exactly the claims a structure is worth building for, so do not let coverage stop at the figures.
+
+## 8. Validate and report
+
+Run [references/checks.md](../references/checks.md). Then say plainly, in the handoff:
+
+- which claims are single-source readings you are unsure of;
+- which predictions and hypotheses you reconstructed rather than found stated;
+- which numbers you could not locate verbatim in the source;
+- which alternatives the paper eliminates without naming, so their nodes are your paraphrase;
+- what the coverage sweep left as gaps.
+
+An extraction that reports none of this has not been checked, it has been asserted.
+
+## Failure modes
+
+**Quantitative hallucination.** A number that is plausible, absent from the paper, and
+uncatchable by a reader. Take every value verbatim; leave the field out if you cannot.
+
+**Panel inflation.** One claim per statistic yields a tree that mirrors the figures and explains
+nothing. The unit is a proposition, not a p-value.
+
+**Reading the discussion as results.** A reframing through outside theory is
+`role: interpretation`, not an empirical claim, however confidently the discussion states it.
+
+**Single-reader bias.** One pass fixes a reading. Where it matters, read the paper more than
+once along different axes — framing, literal numerics, computational structure — and treat a
+claim that only one pass surfaced as single-source: it may be real and buried, or an artefact of
+how you read.
+
+**Silent edge repair.** When `rules-out` has no legal target, the fix is a new alternative node,
+never a redirect to the nearest asserted claim.

--- a/.claude/skills/claim-structures/workflows/design-experiment.md
+++ b/.claude/skills/claim-structures/workflows/design-experiment.md
@@ -1,0 +1,139 @@
+# Design an experiment from its claim structure
+
+Before data. The graph you build here is a design document and, if you fix it before running, a
+preregistration: the same claims, with `stance` and `epistemic` unset and every panel marked
+planned.
+
+The organising idea: **a design is defined by what it can eliminate.** An experiment that would
+produce an interesting result under every hypothesis on the table has not been designed, it has
+been scheduled.
+
+## 1. The question
+
+One sentence, answerable, not naming your preferred answer. Write it as `q1` on the study.
+
+## 2. Enumerate the answers — all of them
+
+Write every answer a competent sceptic would hold, one claim each, `addresses: q1`, stance
+`entertains`:
+
+- **the null** — the effect does not exist;
+- **the confound** — something uninteresting produces the same observation (task difficulty,
+  arousal, motion, expression level, sampling bias);
+- **the rival mechanism** — a different process producing the same phenomenon;
+- **the scope objection** — it is real but confined to this preparation, species, or regime;
+- **the prior framework** — the account the field currently defaults to.
+
+Then mark one as yours: `role: hypothesis`, stance `asserts` when the study asserts it.
+
+Do this before thinking about methods. Enumerating the rivals first is what separates a design
+from a protocol, and it is the only part of this workflow that cannot be recovered afterwards —
+once you have data, the rivals you did not name look like objections rather than options.
+
+## 3. Derive what each answer predicts
+
+For each answer, including the rivals, write the predictions it `entails` under the conditions
+you can actually create. Then build the table that is the heart of the design:
+
+| Prediction | Your hypothesis | Null | Confound | Rival mechanism |
+|:-----------|:----------------|:-----|:---------|:----------------|
+| P1 dose-response is monotonic | yes | no | yes | yes |
+| P2 effect survives the confound control | yes | no | **no** | yes |
+| P3 effect reverses under manipulation M | yes | no | no | **no** |
+
+A row where every column agrees buys nothing. The design is the set of rows where columns
+disagree, and if there are none, the experiment cannot settle the question — change the design
+now rather than discovering it in analysis.
+
+## 4. Plan the measurements as claims
+
+For each discriminating prediction, write the empirical claim you expect to be able to make,
+in full, before collecting anything:
+
+```yaml
+slug: distal-inhibition-suppresses-firing
+claim: >
+  Doubling distal dendritic inhibition reduces somatic firing rate relative to baseline,
+  with the reduction larger than for matched perisomatic inhibition.
+claim-type: empirical
+role: empirical
+epistemic: ~                      # unset until data
+tests: [prediction-distal-dendritic-spike-mechanism]
+requires: [single-cell-model-scope, drive-parameterization]
+assertions:
+  - paper-slug: <study>
+    panel: planned-fig2a
+    analysis: analysis/firing_rate_sweep.py
+    method: compartmental modelling — inhibition magnitude sweep
+    stance: entertains            # nothing is asserted before data
+```
+
+Writing the sentence first forces the design decisions that are otherwise deferred: what is
+measured, in what units, against what comparison, with what effect direction. **If you cannot
+write the sentence without the data, you do not yet know what the experiment measures.** Leave
+the magnitude as a blank to be filled — never as a guessed number, which becomes a fabricated
+result the moment the file is read by anyone else.
+
+Name the analysis path in the claim. A planned claim whose analysis is unnamed is a hope.
+
+## 5. Controls, one per rival
+
+Every rival from step 2 needs a planned control claim carrying `rules-out` to it. Write what
+result would eliminate it — specifically, including the direction and the threshold. A control
+whose outcome you cannot state in advance is not a control.
+
+Two cases to handle explicitly:
+
+- A rival you cannot eliminate with this design. Keep the node, leave it with no incoming
+  `rules-out`, and write the `scope` claim that concedes it. That is an honest design; silence
+  is not.
+- A control that would only be informative if it comes out null. Say so — `validates` is for
+  exactly this, a check whose specific outcome strengthens a warrant.
+
+## 6. Scope and method, written before data
+
+Scope claims: population, preparation, stimulation regime, dose range, model architecture, the
+parameters assumed rather than measured. Point them at the empirical claims they bound, or
+`scopes: ["*"]`.
+
+Methodological claims: every capability the planned interpretation depends on — the sorting
+pipeline, the decoder, the null model, the registration. Where a capability is assumed rather
+than validated in this study, register it as an `assessment` claim with `epistemic: weak` and
+let everything that `requires` it inherit that.
+
+Feasibility belongs here too, as claims with the numbers in them: the sample size the design
+needs for the effect it expects, the runtime, the n per group. A power calculation that lives
+only in a grant is not attached to the claim it constrains.
+
+## 7. Audit the design
+
+Run [references/checks.md](../references/checks.md), then check the design-specific properties:
+
+| Check | Failure means |
+|:------|:--------------|
+| every rival has an incoming `rules-out`, or a scope claim conceding it | an objection the study cannot answer and does not admit |
+| at least one prediction discriminates your hypothesis from each rival | the experiment cannot settle the question |
+| every planned empirical claim names an analysis | a measurement without a method |
+| every claim sentence is writable without the data | the measurement is underspecified |
+| each dissociation has both arms planned | half a contrast establishes nothing |
+| no claim carries a number that does not exist yet | a fabricated result waiting to be quoted |
+| scope claims exist and are pointed at something | the boundaries are unexamined |
+
+## 8. After the data
+
+The graph becomes the record rather than the plan:
+
+- Fill the numbers into the claim sentences, verbatim from the analysis output.
+- Set `stance`: `asserts` for what held, `rejects` for rivals the controls killed, and leave
+  `entertains` on rivals that survived — an open alternative is a finding.
+- Where a prediction came out against you, add `refutes` from the result to the prediction and
+  keep both. A paper refuting its own prediction is the loop closing correctly, and it is the
+  part of the record that is worth the most and gets dropped the most.
+- Set `epistemic` from what the data actually support, bounded by the weakest claim each result
+  `requires`.
+- Add `reproductions` blocks as analyses are run, recording what the code actually opened and
+  actually returned rather than what it was expected to show.
+
+Diffing the pre-data graph against the post-data one gives, exactly: what was predicted, what
+held, what did not, and what was added afterwards. That diff is the thing a preregistration is
+supposed to make possible and usually does not.

--- a/.claude/skills/claim-structures/workflows/spec-paper.md
+++ b/.claude/skills/claim-structures/workflows/spec-paper.md
@@ -1,0 +1,102 @@
+# Spec a paper from its claims
+
+Forward construction: the argument is built as a graph first, and the prose is written from it.
+Use this when the results exist (or are nearly in) and the paper has to be structured, when a
+draft has lost its spine, or when deciding what still has to be done before a paper is possible.
+
+The graph is not a summary of the paper. It is the paper's skeleton, and it is cheap to
+rearrange while it is still a graph.
+
+## 1. State the questions
+
+Two to four at most, each one sentence, each answerable. Write them into the paper's `index.md`
+frontmatter with `q1`, `q2` ids. A question you cannot state without naming your result is not a
+question — it is a finding looking for a frame.
+
+## 2. Commit to an answer, and name the rivals
+
+For each question, write the `hypothesis` claim: the answer this paper commits to, `addresses`
+naming its question. Then write the *other* answers — the rivals a sceptical reader holds —
+each as its own claim with `addresses` pointing at the same question and stance `entertains`.
+
+This is the step that makes the spec worth doing. A paper is persuasive in proportion to how
+credible the alternatives were before it eliminated them, and the alternatives are almost never
+written down until a reviewer supplies them. Writing them first turns review into something you
+run against yourself.
+
+Rivals worth enumerating: the null; the confound (a trivial mechanism that would produce the
+same observation); the scope objection (true, but only in this preparation); the prior framework
+your result is being read against.
+
+## 3. Derive the predictions
+
+For each hypothesis, `entails` the predictions that follow *if it holds* — and, for each rival,
+what that rival predicts instead. State them as conditionals with the conditions attached:
+"if the optimal frequency is set by matching the rhythm period to the local spike timescale,
+then distal inhibition should be maximally effective near 20 Hz."
+
+Predictions shared by your hypothesis and a rival are not evidence, however well they come out.
+The predictions that discriminate are the paper.
+
+## 4. Attach the results
+
+For each prediction, the empirical claim that tests it: one proposition, panel-grounded,
+quantitative. `tests` up to the prediction, `supports` up to the hypothesis.
+
+**This is the figure plan.** One panel per empirical claim, one figure per group of claims that
+share a prediction. A figure whose panels belong to unrelated claims is a layout decision
+masquerading as an argument; a claim with no panel is either a synthesis or a result you do not
+actually have.
+
+Results in hand that test no prediction are the diagnostic: either they belong to a hypothesis
+you have not written down, or they are not part of this paper. Both are useful to learn before
+drafting.
+
+## 5. Kill the rivals, bound the whole
+
+- For each rival, the `control` claim whose result eliminates it, carrying `rules-out`. A rival
+  with no incoming `rules-out` survives into the reviews — decide now whether to run the
+  control, argue it away in the discussion, or keep it as an open alternative and say so.
+- Every `scope` claim: the population, the preparation, the stimulation regime, the model's
+  boundary, the untested parameter. Point them at what they bound, `scopes: ["*"]` where global.
+  Written now they shape the claims; written at the end they become a limitations paragraph.
+- Every `methodological` claim a result leans on, with `enables-method` to the results it
+  warrants. Where the method is assumed rather than validated here, that is an `assessment`
+  claim with `epistemic: weak`, and everything requiring it inherits the weakness.
+- Every `literature-context` premise the argument inherits — especially any framework you
+  position against, which needs a node for the eliminative move to reach.
+
+## 6. Read the top of the graph — that is the abstract
+
+The synthesis and interpretation claims are what the paper concludes. Drafting the abstract from
+them, rather than from the figures, is what keeps the abstract honest: abstracts systematically
+scrub the eliminative moves (`rules-out`, `refutes`) and absorb controls into the main result.
+The structure records what the prose drops.
+
+Section order falls out too: results follow the hypothesis-prediction-test arcs in dependency
+order; the methods section is the methodological and scope claims made continuous; the
+discussion is the interpretation claims plus the scope claims turned outward.
+
+## 7. Audit the spec before drafting
+
+Run [references/checks.md](../references/checks.md), then read the graph for these:
+
+| Symptom | What it means |
+|:--------|:--------------|
+| a rival with no incoming `rules-out` | an unanswered objection — run the control or concede it |
+| a prediction with no `tests` | an untested commitment; drop it or do the experiment |
+| an empirical claim testing nothing | an orphan result, or a hypothesis you have not stated |
+| a synthesis with one `supports` | an overreach: one result is not an integration |
+| no `scope` claims | the boundaries are unexamined, not absent |
+| every edge is `supports` | the argument has no deductive spine — nothing entails, nothing tests |
+| a hypothesis with one prediction | the design has one point of contact with the world |
+
+## 8. Keep the graph alive while drafting
+
+When a reviewer objects, the objection is a rival: add the node, and either the control that
+kills it or the scope claim that concedes it. When a result changes, the claim sentence changes
+and everything that `requires` it is flagged for re-reading. When a figure is cut, the claims it
+carried are visibly orphaned rather than quietly lost.
+
+The version of the tree that ships alongside the paper is what lets a reader check the argument
+rather than reconstruct it — which is the thing the corpus this skill comes from exists to test.


### PR DESCRIPTION
An agent skill for using claim structures in work — not only for editing this corpus. Lives at `.claude/skills/claim-structures/`.

One `SKILL.md` over the format (claim as entity vs. assertion, the two axes, the spine, eight invariants), two references (full schema; the 20 relations with direction and the confusable pairs), one audit pass (`checks.md`), and three workflows for the three directions the same graph gets walked:

- **analyze-paper** — reverse construction, a finished argument into claims. JATS-over-PDF intake, panel sweep, recover the spine, coverage, report what was reconstructed rather than found.
- **spec-paper** — forward construction. Questions → committed answer + named rivals → predictions → results as the figure plan. The top of the graph is the abstract.
- **design-experiment** — before data. Enumerate every answer a sceptic holds, build the table of predictions where the rivals disagree, plan claims with the magnitudes left blank. The pre/post-data diff is what a preregistration is supposed to make possible.

Content is drawn from `docs/claim-format.md`, `docs/vocabulary.md` and `docs/method.md`, with edge directions from `scripts/relations.py`; the open relation-semantics question (#19) is left open rather than silently resolved. Self-contained, so it works outside this repository — repo tooling is confined to one section.

Verified: frontmatter parses, all internal links resolve, every cited slug exists in `claims/headley-2026-inhibitory-rhythms/`, and the three commands it names are real. Markdown only under `.claude/` — no corpus, site or pipeline file is touched.

Untested in practice. It goes in to be used by agents doing real work, which is the only way its gaps will surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)