### PR TITLE
feat(skills): the overlay rule for human-facing artifacts

### DIFF
--- a/.claude/skills/claim-structures/SKILL.md
+++ b/.claude/skills/claim-structures/SKILL.md
@@ -93,6 +93,7 @@ that have to be eliminated to the measurements that eliminate them.
 | speccing or restructuring a paper you are writing | [workflows/spec-paper.md](workflows/spec-paper.md) |
 | designing an experiment or study before data exists | [workflows/design-experiment.md](workflows/design-experiment.md) |
 | checking a structure someone else built | [references/checks.md](references/checks.md) |
+| handing a structure to a person to read | [references/presentation.md](references/presentation.md) |
 
 ## Invariants
 
@@ -119,7 +120,10 @@ of them.
    Written afterwards, they become a discussion paragraph nobody traverses.
 7. **The graph is the argument.** Read the edges alone, with the claim sentences, and see
    whether the argument reconstructs. If it does not, the edges are wrong — not the reader.
-8. **Do not fabricate identifiers.** Generate UUIDs (`python3 -c "import uuid; print(uuid.uuid4())"`).
+8. **The structure is not the artifact.** When the deliverable is for a person, overlay the
+   claims onto their document — anchored to the spans they came from, in plain wording, with the
+   gaps shown — rather than pasting claim files into it.
+9. **Do not fabricate identifiers.** Generate UUIDs (`python3 -c "import uuid; print(uuid.uuid4())"`).
    Take panel ids from the source's own figure elements. Leave `doi: ~` unless the DOI is real.
 
 ## Stance, and why it is on the assertion

--- a/.claude/skills/claim-structures/references/presentation.md
+++ b/.claude/skills/claim-structures/references/presentation.md
@@ -1,0 +1,113 @@
+# Handing a claim structure to a human
+
+The structure is infrastructure. It is not the artifact a person reads, and pasting it into one
+produces a document nobody wants: thirty YAML blocks where a paper used to be.
+
+**The default is an overlay.** The human keeps their own document — the paper, the draft, the
+protocol — and the claims arrive anchored to the spans that carry them. The structure annotates
+the text; it does not replace it, summarise it away, or stand in front of it.
+
+The exception is narrow and worth naming: when the deliverable *is* the structure — a corpus
+contribution, an export, a file another tool will parse, a review another analyst will edit —
+verbatim claim files are exactly right. Everything below is about the other case.
+
+## What the reader wants, in order
+
+A reader arriving at an annotated paper wants four things, in this order:
+
+1. What does this paper claim?
+2. How do those claims hold each other up?
+3. What can I take away and use?
+4. And only then — how was this made, and how far has it got?
+
+The order is not arbitrary. The first is the paper; the last is us. A reader who cannot get the
+first is not helped by the fourth, and an artifact that leads with provenance is an artifact
+about its own machinery. Put the verification banner, the model names, the run ledger and the
+layer map *after* the science, or in a view of their own. A green box at the top of someone
+else's paper is one step's result wearing the paper's headline.
+
+## Anchor to spans, and name the misses
+
+The working form in this repository is `marked/<paper>.marked.md`: the paper's own prose, in its
+own order, with one anchored note per span that carries a result.
+
+```
+Choices: manipulation check As expected, participants' probability of choosing the risky
+option increased with the difference between the expected value …⟦>zach claim=86ccf2d0-…:
+@{…quoted span…} participants-probability-choosing-risky-option⟧
+```
+
+Three properties make it useful, and all three are worth reproducing in any overlay you build:
+
+- **The note quotes the span it is attached to**, so the anchor survives reformatting and is
+  checkable by eye.
+- **The key is the claim's UUID**, not its slug or its sentence — the identity that does not
+  move when wording does.
+- **Misses are first-class.** `claim=gap` marks a result no claim accounts for; `claim=no-assertion`
+  marks a span that states no result (a paradigm narration, a figure title, a forward
+  reference). An unmarked sentence carried no result and was never an obligation. An overlay
+  that shows only its hits cannot be audited — it looks complete whatever it missed.
+
+Gädeke's marked document carries 5 gaps and 16 no-assertions beside its claim anchors. That
+ratio is the honest part of the artifact.
+
+## Plain wording is what the reader meets first
+
+Claims are recorded in the authors' words, and that is right: the corpus must be able to show
+what the paper said, and a paraphrase is not evidence of anything. But the authors' words open
+with the statistics —
+
+> Being the decision-maker (Social + Solo vs Partner condition) reduces participant happiness
+> independently of outcome (Study 1: t(3600)=−3.92, p<0.0001, …)
+
+— and a page listing thirty of those has told a non-specialist nothing they can act on.
+
+So: **the formal `claim` sentence stays canonical and unedited; a plain restatement is what the
+reader meets.** One plain sentence per claim, the statistics behind a disclosure rather than in
+front of the proposition. `shortClaim` was meant to serve this and is filled for hypotheses and
+predictions only; `scripts/plain_claims.py` fills it for the rest as a layer.
+
+Two rules that follow, and both are easy to get wrong:
+
+- **Never rewrite the formal claim to make it readable.** The readable form is an additional
+  field, produced and versioned separately, and it goes stale when the claim it restates
+  changes.
+- **Mark model-written prose as model-written.** A reader will take a fluent restatement for the
+  paper's own words unless told otherwise. This is the whole reason the plain layer is a layer
+  with a version, a recorded run, and a place for a person to approve it, rather than a field
+  somebody edits.
+
+## What stays behind the surface
+
+Machine surfaces that do not belong in a human artifact's body text: UUIDs, `priority`, raw
+relation lists, `claim-type` alongside `role`, run ids, model names, input hashes. They belong
+in the detail view a reader opens for one claim — the drawer — or in a provenance view, not
+inline where they crowd out the proposition.
+
+The edges are the exception worth surfacing, because they answer question 2 — but surface them
+as the argument, not as a list of typed tuples. "This is ruled out by the control in Figure 4"
+is the edge; `rules-out: [alt-…]` is its storage.
+
+## Two surfaces, one state
+
+A tree gets read on screen and on paper, and the two must show the same state. The repository
+does this with the Reader — claims in the margin of the paper — and
+`scripts/review_document.py`, which regenerates the printable document from the current claim
+files and carries any verdict already recorded, so a reading begun in one surface is visible in
+the other. If you build an overlay that a person will mark up, decide where their marks land
+before they make any, and regenerate the other surface from the same source rather than letting
+the two drift.
+
+## Checklist
+
+Before handing over a human-facing artifact built from a claim structure:
+
+- [ ] the person's own document is intact, in its own order, and readable with the overlay off
+- [ ] every claim is anchored to the span it came from, quoting it
+- [ ] gaps and no-assertion spans are shown, not only hits
+- [ ] the wording a reader meets first is plain; the formal sentence is available, unedited
+- [ ] model-written prose is labelled as model-written
+- [ ] no UUIDs, hashes or run ids in body text
+- [ ] edges appear as argument, not as tuples
+- [ ] provenance and verification come after the science, not above it
+- [ ] what the structure does *not* cover is stated where a reader will see it

--- a/.claude/skills/claim-structures/workflows/analyze-paper.md
+++ b/.claude/skills/claim-structures/workflows/analyze-paper.md
@@ -120,6 +120,9 @@ Run [references/checks.md](../references/checks.md). Then say plainly, in the ha
 
 An extraction that reports none of this has not been checked, it has been asserted.
 
+If what you hand over is for a person to read rather than for a corpus to hold, build it as an
+overlay on the paper's own text — see [references/presentation.md](../references/presentation.md).
+
 ## Failure modes
 
 **Quantitative hallucination.** A number that is plausible, absent from the paper, and

--- a/.claude/skills/claim-structures/workflows/spec-paper.md
+++ b/.claude/skills/claim-structures/workflows/spec-paper.md
@@ -98,5 +98,6 @@ kills it or the scope claim that concedes it. When a result changes, the claim s
 and everything that `requires` it is flagged for re-reading. When a figure is cut, the claims it
 carried are visibly orphaned rather than quietly lost.
 
-The version of the tree that ships alongside the paper is what lets a reader check the argument
-rather than reconstruct it — which is the thing the corpus this skill comes from exists to test.
+The version of the tree that ships alongside the paper is an overlay on the paper, not a
+replacement for it ([references/presentation.md](../references/presentation.md)) — and it is what
+lets a reader check the argument rather than reconstruct it — which is the thing the corpus this skill comes from exists to test.


### PR DESCRIPTION
Follow-up to #117. The skill said how to build a claim structure and nothing about how one reaches a reader — which leaves the obvious failure available: paste the claim files into the deliverable and hand someone thirty YAML blocks where a paper used to be.

New `references/presentation.md` states the default — **the person keeps their own document, and the claims arrive anchored to the spans that carry them** — with the specifics taken from what this repo already does rather than invented:

- the anchored-note form in `marked/`, where the key is the claim's UUID and `gap` / `no-assertion` are first-class, so an overlay cannot look complete whatever it missed (Gädeke carries 5 and 16 of them);
- the plain-wording rule behind `scripts/plain_claims.py` — the formal claim sentence stays canonical and unedited, a plain restatement is what the reader meets, and model-written prose is labelled as model-written because a reader will otherwise take it for the paper's own words;
- the reader-first ordering from `docs/design/2026-09-11-the-paper-page.html`: what does it claim → how do the claims hold each other up → what can I take away → and only then how it was made. Provenance after the science, not in a banner above it;
- the two-surfaces requirement `scripts/review_document.py` exists to satisfy.

The exception is named rather than left implicit: when the deliverable *is* the structure — an export, a corpus contribution, a review another analyst edits — verbatim claim files are right.

Wired in as an eighth invariant and a routing row in `SKILL.md`, with pointers from the analyze and spec workflows at the point each produces something for a person. Markdown only under `.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)